### PR TITLE
add tests

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -109,7 +109,6 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 	}
 
 	ev.AddField("status.code", int32(data.Status))
-	ev.AddField("status.message", data.Status.String())
 	// If the status isn't zero, set error to be true
 	if data.Status != 0 {
 		ev.AddField("error", true)
@@ -122,7 +121,7 @@ var _ trace.Exporter = (*Exporter)(nil)
 
 func honeycombSpan(s *trace.SpanData) *Span {
 	sc := s.SpanContext
-	hcTraceUUID, _ := uuid.Parse(fmt.Sprintf("%x%016x", sc.TraceID.High, sc.TraceID.Low))
+	hcTraceUUID, _ := uuid.Parse(fmt.Sprintf("%016x%016x", sc.TraceID.High, sc.TraceID.Low))
 	// TODO: what should we do with that error?
 
 	hcTraceID := hcTraceUUID.String()

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -1,0 +1,168 @@
+package honeycomb
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"reflect"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	libhoney "github.com/honeycombio/libhoney-go"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/api/core"
+	apitrace "go.opentelemetry.io/api/trace"
+	"go.opentelemetry.io/sdk/trace"
+)
+
+func TestExport(t *testing.T) {
+	now := time.Now().Round(time.Microsecond)
+	traceID := core.TraceID{High: 0x0102030405060708, Low: 0x090a0b0c0d0e0f10}
+	spanID := uint64(0x0102030405060708)
+	expectedTraceID := "01020304-0506-0708-090a-0b0c0d0e0f10"
+	expectedSpanID := uint64(72623859790382856)
+
+	tests := []struct {
+		name string
+		data *trace.SpanData
+		want *Span
+	}{
+		{
+			name: "no parent",
+			data: &trace.SpanData{
+				SpanContext: core.SpanContext{
+					TraceID: traceID,
+					SpanID:  spanID,
+				},
+				Name:      "/foo",
+				StartTime: now,
+				EndTime:   now,
+			},
+			want: &Span{
+				TraceID:       expectedTraceID,
+				ID:            expectedSpanID,
+				Name:          "/foo",
+				Timestamp:     now,
+				DurationMilli: 0,
+				Error:         false,
+			},
+		},
+		{
+			name: "1 day duration",
+			data: &trace.SpanData{
+				SpanContext: core.SpanContext{
+					TraceID: traceID,
+					SpanID:  spanID,
+				},
+				Name:      "/bar",
+				StartTime: now,
+				EndTime:   now.Add(24 * time.Hour),
+			},
+			want: &Span{
+				TraceID:       expectedTraceID,
+				ID:            expectedSpanID,
+				Name:          "/bar",
+				Timestamp:     now,
+				DurationMilli: 86400000,
+				Error:         false,
+			},
+		},
+		{
+			name: "status code OK",
+			data: &trace.SpanData{
+				SpanContext: core.SpanContext{
+					TraceID: traceID,
+					SpanID:  spanID,
+				},
+				Name:      "/baz",
+				StartTime: now,
+				EndTime:   now,
+				Status:    codes.OK,
+			},
+			want: &Span{
+				TraceID:       expectedTraceID,
+				ID:            expectedSpanID,
+				Name:          "/baz",
+				Timestamp:     now,
+				DurationMilli: 0,
+				Error:         false,
+			},
+		},
+		{
+			name: "status code not OK",
+			data: &trace.SpanData{
+				SpanContext: core.SpanContext{
+					TraceID: traceID,
+					SpanID:  spanID,
+				},
+				Name:      "/bazError",
+				StartTime: now,
+				EndTime:   now,
+				Status:    codes.PermissionDenied,
+			},
+			want: &Span{
+				TraceID:       expectedTraceID,
+				ID:            expectedSpanID,
+				Name:          "/bazError",
+				Timestamp:     now,
+				DurationMilli: 0,
+				Error:         true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		got := honeycombSpan(tt.data)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("honeycombSpan:\n\tgot  %#v\n\twant %#v", got, tt.want)
+		}
+	}
+}
+
+func TestHoneycombOutput(t *testing.T) {
+	mockHoneycomb := &libhoney.MockOutput{}
+	assert := assert.New(t)
+
+	trace.Register()
+	exporter := NewExporter("overridden", "overridden")
+	exporter.ServiceName = "opentelemetry-test"
+
+	libhoney.Init(libhoney.Config{
+		WriteKey: "test",
+		Dataset:  "test",
+		Output:   mockHoneycomb,
+	})
+	exporter.Builder = libhoney.NewBuilder()
+
+	trace.RegisterExporter(exporter)
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	_, span := apitrace.GlobalTracer().Start(context.TODO(), "myTestSpan")
+	time.Sleep(time.Duration(0.5 * float64(time.Millisecond)))
+
+	span.Finish()
+
+	assert.Equal(1, len(mockHoneycomb.Events()))
+	traceID := mockHoneycomb.Events()[0].Fields()["trace.trace_id"]
+	honeycombTranslatedTraceUUID, _ := uuid.Parse(fmt.Sprintf("%016x%016x", span.SpanContext().TraceID.High, span.SpanContext().TraceID.Low))
+	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
+
+	assert.Equal(honeycombTranslatedTraceID, traceID)
+
+	spanID := mockHoneycomb.Events()[0].Fields()["trace.span_id"]
+	assert.Equal(span.SpanContext().SpanID, spanID)
+
+	name := mockHoneycomb.Events()[0].Fields()["name"]
+	assert.Equal("myTestSpan", name)
+
+	durationMilli := mockHoneycomb.Events()[0].Fields()["duration_ms"]
+	durationMilliFl, ok := durationMilli.(float64)
+	assert.Equal(ok, true)
+	assert.Equal((durationMilliFl > 0), true)
+	assert.Equal((durationMilliFl < 1), true)
+
+	serviceName := mockHoneycomb.Events()[0].Fields()["service_name"]
+	assert.Equal("opentelemetry-test", serviceName)
+	assert.Equal(mockHoneycomb.Events()[0].Dataset, "test")
+}


### PR DESCRIPTION
Adds test to check the contents of various spans, and an e2e test for a libhoney event

In doing so:
-  I've removed the status.message field since that was returning just an empty string.
- I've fixed the all 0s trace-id. We now get trace-ids, but they're not passed through the from the client request to the server-side test. So, I'll keep brainstorming for how to test that part of things.

![image](https://user-images.githubusercontent.com/10929533/64635547-c5588e80-d3b4-11e9-91a7-dc19c5289a6b.png)
