### PR TITLE
add in the MessageEvent details now that it's exported

### DIFF
--- a/example/server/server.go
+++ b/example/server/server.go
@@ -66,7 +66,7 @@ func main() {
 		)
 		defer span.Finish()
 
-		span.AddEvent(ctx, "handling this...")
+		span.AddEvent(ctx, "handling this...", key.New("request-handled").Int(100))
 
 		_, _ = io.WriteString(w, "Hello, world!\n")
 	}

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -13,6 +13,7 @@ import (
 	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/api/core"
+	"go.opentelemetry.io/api/key"
 	apitrace "go.opentelemetry.io/api/trace"
 	"go.opentelemetry.io/sdk/trace"
 )
@@ -22,7 +23,7 @@ func TestExport(t *testing.T) {
 	traceID := core.TraceID{High: 0x0102030405060708, Low: 0x090a0b0c0d0e0f10}
 	spanID := uint64(0x0102030405060708)
 	expectedTraceID := "01020304-0506-0708-090a-0b0c0d0e0f10"
-	expectedSpanID := uint64(72623859790382856)
+	expectedSpanID := "72623859790382856"
 
 	tests := []struct {
 		name string
@@ -151,7 +152,8 @@ func TestHoneycombOutput(t *testing.T) {
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
 	spanID := mockHoneycomb.Events()[0].Fields()["trace.span_id"]
-	assert.Equal(span.SpanContext().SpanID, spanID)
+	expectedSpanID := fmt.Sprintf("%d", span.SpanContext().SpanID)
+	assert.Equal(expectedSpanID, spanID)
 
 	name := mockHoneycomb.Events()[0].Fields()["name"]
 	assert.Equal("myTestSpan", name)
@@ -165,4 +167,73 @@ func TestHoneycombOutput(t *testing.T) {
 	serviceName := mockHoneycomb.Events()[0].Fields()["service_name"]
 	assert.Equal("opentelemetry-test", serviceName)
 	assert.Equal(mockHoneycomb.Events()[0].Dataset, "test")
+}
+func TestHoneycombOutputWithMessageEvent(t *testing.T) {
+	mockHoneycomb := &libhoney.MockOutput{}
+	assert := assert.New(t)
+
+	trace.Register()
+	exporter := NewExporter("overridden", "overridden")
+	exporter.ServiceName = "opentelemetry-test"
+
+	libhoney.Init(libhoney.Config{
+		WriteKey: "test",
+		Dataset:  "test",
+		Output:   mockHoneycomb,
+	})
+	exporter.Builder = libhoney.NewBuilder()
+
+	trace.RegisterExporter(exporter)
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	ctx, span := apitrace.GlobalTracer().Start(context.TODO(), "myTestSpan")
+	span.AddEvent(ctx, "handling this...", key.New("request-handled").Int(100))
+	time.Sleep(time.Duration(0.5 * float64(time.Millisecond)))
+
+	span.Finish()
+
+	assert.Equal(2, len(mockHoneycomb.Events()))
+
+	// Check the fields on the main span event
+	traceID := mockHoneycomb.Events()[1].Fields()["trace.trace_id"]
+	honeycombTranslatedTraceUUID, _ := uuid.Parse(fmt.Sprintf("%016x%016x", span.SpanContext().TraceID.High, span.SpanContext().TraceID.Low))
+	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
+
+	assert.Equal(honeycombTranslatedTraceID, traceID)
+
+	spanID := mockHoneycomb.Events()[1].Fields()["trace.span_id"]
+	expectedSpanID := fmt.Sprintf("%d", span.SpanContext().SpanID)
+	assert.Equal(expectedSpanID, spanID)
+
+	name := mockHoneycomb.Events()[1].Fields()["name"]
+	assert.Equal("myTestSpan", name)
+
+	durationMilli := mockHoneycomb.Events()[1].Fields()["duration_ms"]
+	durationMilliFl, ok := durationMilli.(float64)
+	assert.Equal(ok, true)
+	assert.Equal((durationMilliFl > 0), true)
+	assert.Equal((durationMilliFl < 1), true)
+
+	serviceName := mockHoneycomb.Events()[1].Fields()["service_name"]
+	assert.Equal("opentelemetry-test", serviceName)
+	assert.Equal(mockHoneycomb.Events()[1].Dataset, "test")
+
+	// Check the fields on the 0 duration Message Event
+	msgEventName := mockHoneycomb.Events()[0].Fields()["name"]
+	assert.Equal("handling this...", msgEventName)
+
+	attribute := mockHoneycomb.Events()[0].Fields()["request-handled"]
+	assert.Equal("100", attribute)
+
+	msgEventTraceID := mockHoneycomb.Events()[0].Fields()["trace.trace_id"]
+	assert.Equal(honeycombTranslatedTraceID, msgEventTraceID)
+
+	msgEventParentID := mockHoneycomb.Events()[0].Fields()["trace.parent_id"]
+	assert.Equal(spanID, msgEventParentID)
+
+	msgEventDurationMilli := mockHoneycomb.Events()[0].Fields()["duration_ms"]
+	assert.Equal(float64(0), msgEventDurationMilli)
+
+	msgEventServiceName := mockHoneycomb.Events()[0].Fields()["service_name"]
+	assert.Equal("opentelemetry-test", msgEventServiceName)
 }


### PR DESCRIPTION
The Jaeger exporter was recently merged into the Opentelemetry-go repo, which made a change to export the MessageEvents Event type.

This change takes advantage of that and adds those details to the 0 duration MessageEvent span.
It adds the Attributes as {AttributeName: AttributeValue}

I added an e2e test for the MessageEvents, and noticed that we were passing the ParentId and SpanID as ints, not as strings. So, I fixed that up too.
https://app.asana.com/0/1136461855218693/1139152411652107?du=579988137396441