### PR TITLE
rename Annotation to SpanEvent

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -35,7 +35,7 @@ type Exporter struct {
 	ServiceName string
 }
 
-// Annotation represents an annotation with a value and a timestamp.
+// SpanEvent represents an event attached to a specific span.
 type SpanEvent struct {
 	Name          string  `json:"name"`
 	TraceID       string  `json:"trace.trace_id"`


### PR DESCRIPTION
We decided to move away from calling MessageEvents annotations and instead call them SpanEvents to be more inline with the OpenTelemetry Spec

Also moves the Timestamp to the base event so as not to get that duplicate timestamp we were seeing before.