### PR TITLE
add spanEvent boolean field

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -41,6 +41,7 @@ type SpanEvent struct {
 	TraceID       string  `json:"trace.trace_id"`
 	ParentID      string  `json:"trace.parent_id,omitempty"`
 	DurationMilli float64 `json:"duration_ms"`
+	SpanEvent     bool    `json:"meta.span_event"`
 }
 
 // Span is the format of trace events that Honeycomb accepts
@@ -129,6 +130,7 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 			TraceID:       getHoneycombTraceID(data.SpanContext.TraceID.High, data.SpanContext.TraceID.Low),
 			ParentID:      fmt.Sprintf("%d", data.SpanContext.SpanID),
 			DurationMilli: 0,
+			SpanEvent:     true,
 		})
 		spanEv.SendPresampled()
 	}

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -232,4 +232,7 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 
 	msgEventServiceName := mockHoneycomb.Events()[0].Fields()["service_name"]
 	assert.Equal("opentelemetry-test", msgEventServiceName)
+
+	spanEvent := mockHoneycomb.Events()[0].Fields()["meta.span_event"]
+	assert.Equal(true, spanEvent)
 }


### PR DESCRIPTION
In order to hide these SpanEvents by default in the UI, I'm adding the `meta.span_event` field