### PR TITLE
move the default sampler to the exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # opentelemetry-exporter-go
 
-The Honeycomb OpenTelemetry exporter for Golang
+# The Honeycomb OpenTelemetry Exporter for Golang
 
 [![CircleCI](https://circleci.com/gh/honeycombio/opentelemetry-exporter-go.svg?style=svg)](https://circleci.com/gh/honeycombio/opentelemetry-exporter-go)
+
+## Default Exporter
+
+The Exporter can be initialized as a default exporter:
+
+```golang
+exporter := honeycomb.NewExporter(<API_KEY>, <DATASET_NAME>)
+exporter.ServiceName = "example-server"
+defer exporter.Close()
+exporter.Register()
+```
+
+## Sampling
+
+The default exporter uses the OpenTelemetry Default Sampler `DefaultSampler: trace.AlwaysSample()` under the hood.
+
+You can configure sampling with Honeycomb with either Deterministic Sampling or Dynamic Sampling.
+
+Read more about [sampling with Honeycomb in our docs](https://docs.honeycomb.io/working-with-your-data/tracing/sampling/).

--- a/example/README.md
+++ b/example/README.md
@@ -1,3 +1,15 @@
-# opentelemetry-exporter-go
+# Example Apps
 
-Pass your Honeycomb API key, found on your Honeycomb Team Settings page and your dataset name as flags when running this example. For example `client -apikey=<your-api-key> -dataset=opentelemetry` ([Sign up for free](https://ui.honeycomb.io/signup) if you haven’t already!)
+Pass your Honeycomb API key, found on your Honeycomb Team Settings page and your dataset name as flags when running this example.
+
+## To run the client/server example:
+
+In `example/server` run `go install && servier -apikey=<your-api-key> -dataset=opentelemetry`
+
+In `example/client` run `go install && client -apikey=<your-api-key> -dataset=opentelemetry`
+
+## To run the basic example:
+
+In `example/basic_example` run `go install && go run main -apikey=<your-api-key> -dataset=opentelemetry`
+
+[Sign up for free](https://ui.honeycomb.io/signup) if you haven’t already!

--- a/example/basic_example/main.go
+++ b/example/basic_example/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/honeycombio/opentelemetry-exporter-go/honeycomb"
 	apitrace "go.opentelemetry.io/api/trace"
-	"go.opentelemetry.io/sdk/trace"
 )
 
 func main() {
@@ -20,11 +19,6 @@ func main() {
 	exporter.ServiceName = "opentelemetry-basic-example"
 	defer exporter.Close()
 	exporter.Register()
-
-	// For demoing purposes, always sample. In a production application, you should
-	// configure this to a trace.ProbabilitySampler set at the desired
-	// probability.
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	ctx := context.Background()
 	ctx, span := apitrace.GlobalTracer().Start(ctx, "/foo")

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/api/tag"
 	apitrace "go.opentelemetry.io/api/trace"
 	"go.opentelemetry.io/plugin/httptrace"
-	"go.opentelemetry.io/sdk/trace"
 
 	"github.com/honeycombio/opentelemetry-exporter-go/honeycomb"
 )
@@ -29,11 +28,6 @@ func main() {
 	exporter.ServiceName = "opentelemetry-client"
 	defer exporter.Close()
 	exporter.Register()
-
-	// For demoing purposes, always sample. In a production application, you should
-	// configure this to a trace.ProbabilitySampler set at the desired
-	// probability.
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	tracer := apitrace.GlobalTracer().
 		WithService("client").

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/api/tag"
 	apitrace "go.opentelemetry.io/api/trace"
 	"go.opentelemetry.io/plugin/httptrace"
-	"go.opentelemetry.io/sdk/trace"
 )
 
 func main() {
@@ -36,11 +35,6 @@ func main() {
 	exporter.ServiceName = "opentelemetry-server"
 	defer exporter.Close()
 	exporter.Register()
-
-	// For demoing purposes, always sample. In a production application, you should
-	// configure this to a trace.ProbabilitySampler set at the desired
-	// probability.
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	tracer := apitrace.GlobalTracer().
 		WithService("server").

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -85,13 +85,11 @@ func NewExporter(apiKey, dataset string) *Exporter {
 		Dataset:  dataset,
 	})
 	builder := libhoney.NewBuilder()
-	// default sample reate is 1: aka no sampling.
-	// set sampleRate on the exporter to be the sample rate given to the
-	// ProbabilitySampler if used.
-	// TODO (akvanhar): Figure out how OpenTelemetry handles sampling
+
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
 	return &Exporter{
-		Builder: builder,
-		// SampleFraction: 1,
+		Builder:     builder,
 		ServiceName: "",
 	}
 }
@@ -104,9 +102,7 @@ func (e *Exporter) Register() {
 // ExportSpan exports a SpanData to Honeycomb.
 func (e *Exporter) ExportSpan(data *trace.SpanData) {
 	ev := e.Builder.NewEvent()
-	// if e.SampleFraction != 0 {
-	// 	ev.SampleRate = uint(1 / e.SampleFraction)
-	// }
+
 	if e.ServiceName != "" {
 		ev.AddField("service_name", e.ServiceName)
 	}

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -132,7 +132,6 @@ func TestHoneycombOutput(t *testing.T) {
 	exporter.Builder = libhoney.NewBuilder()
 
 	exporter.Register()
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	_, span := apitrace.GlobalTracer().Start(context.TODO(), "myTestSpan")
 	time.Sleep(time.Duration(0.5 * float64(time.Millisecond)))
@@ -178,7 +177,6 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	exporter.Builder = libhoney.NewBuilder()
 
 	exporter.Register()
-	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	ctx, span := apitrace.GlobalTracer().Start(context.TODO(), "myTestSpan")
 	span.AddEvent(ctx, "handling this...", key.New("request-handled").Int(100))


### PR DESCRIPTION
Moves the default sampler config to the exporter
Adds a pointer to the honeycomb docs to the main readme and updates the examples readme