### PR TITLE
Add optional debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 The Exporter can be initialized as a default exporter:
 
 ```golang
-exporter := honeycomb.NewExporter(<API_KEY>, <DATASET_NAME>)
+exporter := honeycomb.NewExporter(honeycomb.Config{
+    ApiKey:  <YOUR-API-KEY>,
+    Dataset: <YOUR-DATASET>,
+    Debug:   true, // optional to output to stdout
+})
 exporter.ServiceName = "example-server"
 defer exporter.Close()
 exporter.Register()

--- a/example/basic_example/main.go
+++ b/example/basic_example/main.go
@@ -15,8 +15,13 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter := honeycomb.NewExporter(*apikey, *dataset)
-	exporter.ServiceName = "opentelemetry-basic-example"
+	exporter := honeycomb.NewExporter(honeycomb.Config{
+		ApiKey:      *apikey,
+		Dataset:     *dataset,
+		Debug:       true,
+		ServiceName: "opentelemetry-basic-example",
+	})
+
 	defer exporter.Close()
 	exporter.Register()
 

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -24,8 +24,13 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter := honeycomb.NewExporter(*apikey, *dataset)
-	exporter.ServiceName = "opentelemetry-client"
+	exporter := honeycomb.NewExporter(honeycomb.Config{
+		ApiKey:      *apikey,
+		Dataset:     *dataset,
+		Debug:       true,
+		ServiceName: "opentelemetry-client",
+	})
+
 	defer exporter.Close()
 	exporter.Register()
 

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -31,8 +31,13 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter := honeycomb.NewExporter(*apikey, *dataset)
-	exporter.ServiceName = "opentelemetry-server"
+	exporter := honeycomb.NewExporter(honeycomb.Config{
+		ApiKey:      *apikey,
+		Dataset:     *dataset,
+		Debug:       true,
+		ServiceName: "opentelemetry-server",
+	})
+
 	defer exporter.Close()
 	exporter.Register()
 

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -42,17 +42,10 @@ type Config struct {
 	// field is extremely valuable when you instrument multiple services. If set
 	// it will be added to all events as `service_name`
 	ServiceName string
-	// SamplRate is a positive integer indicating the rate at which to sample
-	// events. Default sampling is at the trace level - entire traces will be
-	// kept or dropped. default: 1 (meaning no sampling)
-	SampleRate uint
 	// Debug will emit verbose logging to STDOUT when true. If you're having
 	// trouble getting the beeline to work, set this to true in a dev
 	// environment.
 	Debug bool
-	// Client, if specified, allows overriding the default client used to send events to Honeycomb
-	// If set, overrides many fields in this config - see descriptions
-	Client *libhoney.Client
 }
 
 // Exporter is an implementation of trace.Exporter that uploads a span to Honeycomb

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	defaultApiKey     = "apikey-placeholder"
-	defaultDataset    = "opentelemetry"
-	defaultSampleRate = 1
+	defaultApiKey  = "apikey-placeholder"
+	defaultDataset = "opentelemetry"
 )
 
 type Config struct {
@@ -112,9 +111,6 @@ func NewExporter(config Config) *Exporter {
 	}
 	if config.Dataset == "" {
 		config.Dataset = defaultDataset
-	}
-	if config.SampleRate == 0 {
-		config.SampleRate = defaultSampleRate
 	}
 
 	libhoneyConfig := libhoney.Config{

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -121,8 +121,11 @@ func TestHoneycombOutput(t *testing.T) {
 	mockHoneycomb := &libhoney.MockOutput{}
 	assert := assert.New(t)
 
-	exporter := NewExporter("overridden", "overridden")
-	exporter.ServiceName = "opentelemetry-test"
+	exporter := NewExporter(Config{
+		ApiKey:      "overridden",
+		Dataset:     "overridden",
+		ServiceName: "opentelemetry-test",
+	})
 
 	libhoney.Init(libhoney.Config{
 		WriteKey: "test",
@@ -166,8 +169,11 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	mockHoneycomb := &libhoney.MockOutput{}
 	assert := assert.New(t)
 
-	exporter := NewExporter("overridden", "overridden")
-	exporter.ServiceName = "opentelemetry-test"
+	exporter := NewExporter(Config{
+		ApiKey:      "overridden",
+		Dataset:     "overridden",
+		ServiceName: "opentelemetry-test",
+	})
 
 	libhoney.Init(libhoney.Config{
 		WriteKey: "test",


### PR DESCRIPTION
**NOTE: Breaking change!**
In order to allow an option debug mode, and to make further additions to the honeycomb config easier in the future, this changes the `NewExporter` call to take a `Config` type, rather than the ApiKey and Dataset directly.
Debug mode is then enabled directly in the config, and that is passed through to the libhoney config.

https://github.com/honeycombio/opentelemetry-exporter-go/issues/15