### PR TITLE
Change spanEvent tag

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -67,7 +67,7 @@ type SpanEvent struct {
 	TraceID       string  `json:"trace.trace_id"`
 	ParentID      string  `json:"trace.parent_id,omitempty"`
 	DurationMilli float64 `json:"duration_ms"`
-	SpanEvent     bool    `json:"meta.span_event"`
+	SpanEventType string  `json:"meta.span_type"`
 }
 
 // Span is the format of trace events that Honeycomb accepts
@@ -168,7 +168,7 @@ func (e *Exporter) ExportSpan(data *trace.SpanData) {
 			TraceID:       getHoneycombTraceID(data.SpanContext.TraceID.High, data.SpanContext.TraceID.Low),
 			ParentID:      fmt.Sprintf("%d", data.SpanContext.SpanID),
 			DurationMilli: 0,
-			SpanEvent:     true,
+			SpanEventType: "span_event",
 		})
 		spanEv.SendPresampled()
 	}

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -235,6 +235,6 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	msgEventServiceName := mockHoneycomb.Events()[0].Fields()["service_name"]
 	assert.Equal("opentelemetry-test", msgEventServiceName)
 
-	spanEvent := mockHoneycomb.Events()[0].Fields()["meta.span_event"]
-	assert.Equal(true, spanEvent)
+	spanEvent := mockHoneycomb.Events()[0].Fields()["meta.span_type"]
+	assert.Equal("span_event", spanEvent)
 }


### PR DESCRIPTION
As per [the slack conversation](https://houndsh.slack.com/archives/CM4MFEM3K/p1568659034011800?thread_ts=1568659034.011800), let's use the existing meta.span_type field that we use in other beelines, setting the value to span_event.

We will look at this tag on the Honeycomb side and handle these spans accordingly