### PR TITLE
expose APIHost so i can point this at my local api instance

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -46,6 +46,9 @@ type Config struct {
 	// trouble getting the beeline to work, set this to true in a dev
 	// environment.
 	Debug bool
+	// APIHost is the hostname for the Honeycomb API server to which to send
+	// this event. default: https://api.honeycomb.io/
+	APIHost string
 }
 
 // Exporter is an implementation of trace.Exporter that uploads a span to Honeycomb
@@ -121,6 +124,10 @@ func NewExporter(config Config) *Exporter {
 	if config.Debug {
 		libhoneyConfig.Logger = &libhoney.DefaultLogger{}
 	}
+	if config.APIHost != "" {
+		libhoneyConfig.APIHost = config.APIHost
+	}
+
 	libhoney.Init(libhoneyConfig)
 	builder := libhoney.NewBuilder()
 

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -47,7 +47,7 @@ type Config struct {
 	// environment.
 	Debug bool
 	// APIHost is the hostname for the Honeycomb API server to which to send
-	// this event. default: https://api.honeycomb.io/
+	// these events. default: https://api.honeycomb.io/
 	APIHost string
 }
 


### PR DESCRIPTION
This exposes the APIHost config field so I can run this locally.
Libhoney will default to api.honeycomb.io if this is not explicitly set, so no need to provide that default here.