### PR TITLE
Fix flakey test

### DIFF
--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -229,7 +229,6 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	durationMilliFl, ok := durationMilli.(float64)
 	assert.Equal(ok, true)
 	assert.Equal((durationMilliFl > 0), true)
-	assert.Equal((durationMilliFl < 1), true)
 
 	serviceName := messageEventFields["service_name"]
 	assert.Equal("opentelemetry-test", serviceName)


### PR DESCRIPTION
Removes flaky test. 
This test has flaked a few times, let's remove it.
Duration should be more than 0, but we don't really care if it's less than 1. It's more likely to fail on circleci than locally.