### PR TITLE
update otel, and switch to using TraceIdString and SpanIDString

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/klauspost/cpuid v1.2.1 // indirect
 	github.com/stretchr/testify v1.3.0
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
-	go.opentelemetry.io v0.0.0-20191004071710-b5c984b839f5
+	go.opentelemetry.io v0.0.0-20191008185658-c2d5c6699002
 	google.golang.org/grpc v1.23.0
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opentelemetry.io v0.0.0-20191004071710-b5c984b839f5 h1:l3j1A0b1WvZXVki+T9EkKwd63DuSKqREHtcabHdWbuU=
 go.opentelemetry.io v0.0.0-20191004071710-b5c984b839f5/go.mod h1:YaHPI8ROvFl7G8kJowNXLXnmLGX3vXP5UxrjgbisZHA=
+go.opentelemetry.io v0.0.0-20191008185658-c2d5c6699002 h1:saYIjw5UH1bZrc6fbvJOsfc9PTicyjC4FG5nDOQBT4o=
+go.opentelemetry.io v0.0.0-20191008185658-c2d5c6699002/go.mod h1:YaHPI8ROvFl7G8kJowNXLXnmLGX3vXP5UxrjgbisZHA=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/api/core"
 	"go.opentelemetry.io/api/key"
 	apitrace "go.opentelemetry.io/api/trace"
-	"go.opentelemetry.io/sdk/trace"
+	"go.opentelemetry.io/sdk/export"
 )
 
 func TestExport(t *testing.T) {
@@ -23,16 +23,16 @@ func TestExport(t *testing.T) {
 	traceID := core.TraceID{High: 0x0102030405060708, Low: 0x090a0b0c0d0e0f10}
 	spanID := uint64(0x0102030405060708)
 	expectedTraceID := "01020304-0506-0708-090a-0b0c0d0e0f10"
-	expectedSpanID := "72623859790382856"
+	expectedSpanID := "0102030405060708"
 
 	tests := []struct {
 		name string
-		data *trace.SpanData
+		data *export.SpanData
 		want *Span
 	}{
 		{
 			name: "no parent",
-			data: &trace.SpanData{
+			data: &export.SpanData{
 				SpanContext: core.SpanContext{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -51,7 +51,7 @@ func TestExport(t *testing.T) {
 		},
 		{
 			name: "1 day duration",
-			data: &trace.SpanData{
+			data: &export.SpanData{
 				SpanContext: core.SpanContext{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -70,7 +70,7 @@ func TestExport(t *testing.T) {
 		},
 		{
 			name: "status code OK",
-			data: &trace.SpanData{
+			data: &export.SpanData{
 				SpanContext: core.SpanContext{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -90,7 +90,7 @@ func TestExport(t *testing.T) {
 		},
 		{
 			name: "status code not OK",
-			data: &trace.SpanData{
+			data: &export.SpanData{
 				SpanContext: core.SpanContext{
 					TraceID: traceID,
 					SpanID:  spanID,
@@ -156,7 +156,7 @@ func TestHoneycombOutput(t *testing.T) {
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
 	spanID := mainEventFields["trace.span_id"]
-	expectedSpanID := fmt.Sprintf("%d", span.SpanContext().SpanID)
+	expectedSpanID := span.SpanContext().SpanIDString()
 	assert.Equal(expectedSpanID, spanID)
 
 	name := mainEventFields["name"]
@@ -219,7 +219,7 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
 	spanID := messageEventFields["trace.span_id"]
-	expectedSpanID := fmt.Sprintf("%d", span.SpanContext().SpanID)
+	expectedSpanID := span.SpanContext().SpanIDString()
 	assert.Equal(expectedSpanID, spanID)
 
 	name := messageEventFields["name"]


### PR DESCRIPTION
Upgrades to the latest OTel
This pulls out our custom parsing of `traceID` and uses `TraceIdString` and `SpanIDString` instead. Still uses UUID to parse it, though.