### PR TITLE
add error handling

### DIFF
--- a/example/basic_example/main.go
+++ b/example/basic_example/main.go
@@ -25,7 +25,9 @@ func main() {
 		Debug:       true,
 		ServiceName: "opentelemetry-basic-example",
 	})
-	log.Fatal(err)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	defer exporter.Close()
 	exporter.RegisterSimpleSpanProcessor()

--- a/example/basic_example/main.go
+++ b/example/basic_example/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"flag"
+	"log"
 
 	"github.com/honeycombio/opentelemetry-exporter-go/honeycomb"
 	apitrace "go.opentelemetry.io/api/trace"
@@ -18,12 +19,13 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter := honeycomb.NewExporter(honeycomb.Config{
+	exporter, err := honeycomb.NewExporter(honeycomb.Config{
 		ApiKey:      *apikey,
 		Dataset:     *dataset,
 		Debug:       true,
 		ServiceName: "opentelemetry-basic-example",
 	})
+	log.Fatal(err)
 
 	defer exporter.Close()
 	exporter.RegisterSimpleSpanProcessor()

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -34,7 +34,9 @@ func main() {
 		Debug:       true,
 		ServiceName: "opentelemetry-client",
 	})
-	log.Fatal(err)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	defer exporter.Close()
 	exporter.RegisterSimpleSpanProcessor()

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 
 	"google.golang.org/grpc/codes"
@@ -27,12 +28,13 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter := honeycomb.NewExporter(honeycomb.Config{
+	exporter, err := honeycomb.NewExporter(honeycomb.Config{
 		ApiKey:      *apikey,
 		Dataset:     *dataset,
 		Debug:       true,
 		ServiceName: "opentelemetry-client",
 	})
+	log.Fatal(err)
 
 	defer exporter.Close()
 	exporter.RegisterSimpleSpanProcessor()
@@ -44,7 +46,7 @@ func main() {
 
 	var body []byte
 
-	err := apitrace.GlobalTracer().WithSpan(ctx, "say hello",
+	err = apitrace.GlobalTracer().WithSpan(ctx, "say hello",
 		func(ctx context.Context) error {
 			req, _ := http.NewRequest("GET", "http://localhost:7777/hello", nil)
 

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/honeycombio/opentelemetry-exporter-go/honeycomb"
@@ -35,12 +36,15 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter := honeycomb.NewExporter(honeycomb.Config{
+	exporter, err := honeycomb.NewExporter(honeycomb.Config{
 		ApiKey:      *apikey,
 		Dataset:     *dataset,
 		Debug:       true,
 		ServiceName: "opentelemetry-server",
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	defer exporter.Close()
 	exporter.RegisterSimpleSpanProcessor()
@@ -67,8 +71,8 @@ func main() {
 	}
 
 	http.HandleFunc("/hello", helloHandler)
-	err := http.ListenAndServe(":7777", nil)
+	err = http.ListenAndServe(":7777", nil)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -205,7 +205,9 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 			SpanEventType: "span_event",
 		})
 		err := spanEv.SendPresampled()
-		e.OnError(err)
+		if err != nil {
+			e.OnError(err)
+		}
 	}
 	for _, kv := range data.Attributes {
 		ev.AddField(getValueFromCoreAttribute(kv))
@@ -218,7 +220,9 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 	}
 
 	err := ev.SendPresampled()
-	e.OnError(err)
+	if err != nil {
+		e.OnError(err)
+	}
 }
 
 var _ export.SpanSyncer = (*Exporter)(nil)

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -122,11 +122,12 @@ func TestHoneycombOutput(t *testing.T) {
 	mockHoneycomb := &libhoney.MockOutput{}
 	assert := assert.New(t)
 
-	exporter := NewExporter(Config{
+	exporter, err := NewExporter(Config{
 		ApiKey:      "overridden",
 		Dataset:     "overridden",
 		ServiceName: "opentelemetry-test",
 	})
+	assert.Equal(err, nil)
 
 	libhoney.Init(libhoney.Config{
 		WriteKey: "test",
@@ -189,11 +190,12 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	mockHoneycomb := &libhoney.MockOutput{}
 	assert := assert.New(t)
 
-	exporter := NewExporter(Config{
+	exporter, err := NewExporter(Config{
 		ApiKey:      "overridden",
 		Dataset:     "overridden",
 		ServiceName: "opentelemetry-test",
 	})
+	assert.Equal(err, nil)
 
 	libhoney.Init(libhoney.Config{
 		WriteKey: "test",


### PR DESCRIPTION
This adds error handling in 2 ways.
1. It returns an error if we're unable to initialize libhoney when trying to register the exporter
2. It adds an OnError handler to the config and exporter that defaults to logging when we are unable to send an event to honeycomb.
Resolves https://github.com/honeycombio/opentelemetry-exporter-go/issues/29