### PR TITLE
adds support for links

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -227,9 +227,9 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 	for _, link := range data.Links {
 		linkEv := e.Builder.NewEvent()
 		linkEv.Add(Link{
-			TraceID:     getHoneycombTraceID(data.SpanContext.TraceID.High, data.SpanContext.TraceID.Low),
+			TraceID:     getHoneycombTraceID(data.SpanContext.TraceIDString()),
 			ParentID:    fmt.Sprintf("%d", data.SpanContext.SpanID),
-			LinkTraceID: getHoneycombTraceID(link.TraceID.High, link.TraceID.Low),
+			LinkTraceID: getHoneycombTraceID(link.TraceIDString()),
 			LinkSpanID:  fmt.Sprintf("%d", link.SpanID),
 			SpanType:    "link",
 			// TODO(akvanhar): properly set the reference type when specs are defined

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -93,8 +93,9 @@ const (
 	SpanRefType_FOLLOWS_FROM SpanRefType = 1
 )
 
-// Link represents a link to a span that lives elsewhere.
+// Link represents a link to a trace and span that lives elsewhere.
 // TraceID and ParentID are used to identify the span with which the trace is associated
+// We are modeling Links for now as child spans rather than properties of the event.
 type Link struct {
 	TraceID     string      `json:"trace.trace_id"`
 	ParentID    string      `json:"trace.parent_id,omitempty"`


### PR DESCRIPTION
This is the main Link struct.
The Trace is the current trace (so we know where to visualize it)
The ParentID is the span that is currently active
The other 4 methods are related to the link itself - the trace and span ids from the span context, the refType - which is currently unsupported. (For now, I'm using Child_Of like the Jaeger exporter does, but have put in a todo to update that when there are different ref types)
`SpanType` will be used in the UI to pull these out into the trace sidebar.
```
type Link struct {
	TraceID     string      `json:"trace.trace_id"`
	ParentID    string      `json:"trace.parent_id,omitempty"`
	LinkTraceID string      `json:"trace.link.trace_id"`
	LinkSpanID  string      `json:"trace.link.span_id"`
	SpanType    string      `json:"meta.span_type"`
	RefType     SpanRefType `json:"ref_type,omitempty"`
}
```