### PR TITLE
turn on go modules for circle-ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,11 @@ executors:
       goversion:
         type: string
         default: "11"
-    working_directory: /go/src/github.com/honeycombio/opentelemetry-exporter-go
     docker:
       - image: circleci/golang:1.<< parameters.goversion >>
+        environment:
+          GO111MODULE: "on"
+    working_directory: /go/src/github.com/honeycombio/opentelemetry-exporter-go
 
 jobs:
   test_opentelemetry:


### PR DESCRIPTION
Previously, go modules wasn't turned on, so circleci was pulling the latest otel - which inevitably broke the build if I hadn't updated in ... a day or two.