### PR TITLE
Update OpenTelemetry to 20191031 version

### DIFF
--- a/example/client/client.go
+++ b/example/client/client.go
@@ -56,7 +56,7 @@ func main() {
 
 	client := http.DefaultClient
 	ctx := distributedcontext.NewContext(context.Background(),
-		distributedcontext.Insert(key.New("username").String("donuts")),
+		key.String("username", "donuts"),
 	)
 
 	var body []byte

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/klauspost/compress v1.9.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
-	go.opentelemetry.io v0.0.0-20191029202722-937f4ff8b0ad
+	go.opentelemetry.io v0.0.0-20191031063502-886243699327
 	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opentelemetry.io v0.0.0-20191029202722-937f4ff8b0ad h1:pM6QTAIVU3P0uGj22HSF5G6Kea3sqFQ005xepNPv0aE=
 go.opentelemetry.io v0.0.0-20191029202722-937f4ff8b0ad/go.mod h1:baUDdfs+tna2bGSgGRSGi3vdulATD4f9KEce9+v4zUA=
+go.opentelemetry.io v0.0.0-20191031063502-886243699327 h1:RNus8zpY56qn80T6sqMFKN6dtSca9vYyYkKFTdYoyqg=
+go.opentelemetry.io v0.0.0-20191031063502-886243699327/go.mod h1:baUDdfs+tna2bGSgGRSGi3vdulATD4f9KEce9+v4zUA=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.opentelemetry.io/api/core"
 	"google.golang.org/grpc/codes"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -140,7 +139,7 @@ func (e *Exporter) Close() {
 // Don't have a Honeycomb account? Sign up at https://ui.honeycomb.io/signup
 func NewExporter(config Config) (*Exporter, error) {
 	// Developer note: bump this with each release
-	versionStr := "0.0.8"
+	versionStr := "0.0.9"
 	libhoney.UserAgentAddition = "Honeycomb-OpenTelemetry-exporter/" + versionStr
 
 	if config.ApiKey == "" {
@@ -247,7 +246,7 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *export.SpanData) {
 	}
 
 	for _, kv := range data.Attributes {
-		ev.AddField(getValueFromCoreAttribute(kv))
+		ev.AddField(string(kv.Key), kv.Value.AsInterface())
 	}
 
 	ev.AddField("status.code", int32(data.Status))
@@ -287,23 +286,4 @@ func honeycombSpan(s *export.SpanData) *Span {
 		hcSpan.Error = true
 	}
 	return hcSpan
-}
-
-func getValueFromCoreAttribute(kv core.KeyValue) (string, interface{}) {
-	var tagValue interface{}
-	switch kv.Value.Type {
-	case core.BOOL:
-		tagValue = kv.Value.Bool
-	case core.INT64:
-		tagValue = kv.Value.Int64
-	case core.UINT64:
-		tagValue = kv.Value.Uint64
-	case core.FLOAT64:
-		tagValue = kv.Value.Float64
-	case core.STRING:
-		tagValue = kv.Value.String
-	case core.BYTES:
-		tagValue = kv.Value.Bytes
-	}
-	return string(kv.Key), tagValue
 }


### PR DESCRIPTION
Updates distributedcontext and keyvalue syntax. (PRs that forced us to change below)

https://github.com/open-telemetry/opentelemetry-go/pull/256
https://github.com/open-telemetry/opentelemetry-go/pull/252