### PR TITLE
NewProvider is the new standard init method.

### DIFF
--- a/example/client/client.go
+++ b/example/client/client.go
@@ -23,7 +23,6 @@ import (
 )
 
 func initTracer(exporter *honeycomb.Exporter) {
-	exporter.RegisterSimpleSpanProcessor()
 	// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
 	// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
 	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -31,7 +31,6 @@ import (
 )
 
 func initTracer(exporter *honeycomb.Exporter) {
-	exporter.RegisterSimpleSpanProcessor()
 	// For the demonstration, use sdktrace.AlwaysSample sampler to sample all traces.
 	// In a production application, use sdktrace.ProbabilitySampler with a desired probability.
 	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -61,7 +61,6 @@ type Config struct {
 
 // Exporter is an implementation of trace.Exporter that uploads a span to Honeycomb
 type Exporter struct {
-	once           sync.Once
 	Builder        *libhoney.Builder
 	SampleFraction float64
 	// Service Name identifies your application. While optional, setting this
@@ -179,14 +178,6 @@ func NewExporter(config Config) (*Exporter, error) {
 		ServiceName: config.ServiceName,
 		OnError:     onError,
 	}, nil
-}
-
-func (e *Exporter) RegisterSimpleSpanProcessor() {
-	// Wrap the exporter with SimpleSpanProcessor and register the processor.
-	e.once.Do(func() {
-		ssp := trace.NewSimpleSpanProcessor(e)
-		trace.RegisterSpanProcessor(ssp)
-	})
 }
 
 // ExportSpan exports a SpanData to Honeycomb.

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/hex"
 	"log"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -27,7 +26,6 @@ import (
 
 	libhoney "github.com/honeycombio/libhoney-go"
 	"go.opentelemetry.io/sdk/export"
-	"go.opentelemetry.io/sdk/trace"
 )
 
 const (

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -134,7 +134,6 @@ func setUpTestExporter(mockHoneycomb *libhoney.MockOutput) (apitrace.Tracer, err
 	})
 	exporter.Builder = libhoney.NewBuilder()
 
-	exporter.RegisterSimpleSpanProcessor()
 	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 		sdktrace.WithSyncer(exporter))
 	global.SetTraceProvider(tp)


### PR DESCRIPTION
We no longer need SimpleSpanProcessor as the boilerplate is a lot more efficient now out of the box with otel.