### PR TITLE
Configure exporter mostly with functional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-exporter-go
 
-# The Honeycomb OpenTelemetry Exporter for Golang
+# The Honeycomb OpenTelemetry Exporter for Go
 
 [![CircleCI](https://circleci.com/gh/honeycombio/opentelemetry-exporter-go.svg?style=svg)](https://circleci.com/gh/honeycombio/opentelemetry-exporter-go)
 
@@ -9,12 +9,13 @@
 The Exporter can be initialized using `sdktrace.WithSyncer`:
 
 ```golang
-exporter, _ := honeycomb.NewExporter(honeycomb.Config{
-    ApiKey:  <YOUR-API-KEY>,
-    Dataset: <YOUR-DATASET>,
-    Debug:   true, // optional to output to stdout
-    ServiceName: "example-server",
-})
+exporter, _ := honeycomb.NewExporter(
+	honeycomb.Config{
+		APIKey:  <YOUR-API-KEY>,
+	},
+	honeycomb.TargetingDataset(<YOUR-DATASET>),
+	honeycomb.WithServiceName("example-server),
+	honeycomb.WithDebugEnabled()) // optional to output diagnostic logs to STDOUT
 
 defer exporter.Close()
 sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
@@ -27,4 +28,4 @@ Read more about [sampling with Honeycomb in our docs](https://docs.honeycomb.io/
 
 ## Example
 
-You can find an example Honeycomb app in [/example](./example)
+You can find an example Honeycomb app in [/example](./example).

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -38,12 +38,12 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter, err := honeycomb.NewExporter(honeycomb.Config{
-		APIKey:      *apikey,
-		Dataset:     *dataset,
-		Debug:       true,
-		ServiceName: "opentelemetry-client",
-	})
+	exporter, err := honeycomb.NewExporter(
+		honeycomb.Config{},
+		honeycomb.UsingAPIKey(*apikey),
+		honeycomb.TargetingDataset(*dataset),
+		honeycomb.WithServiceName("opentelemetry-client"),
+		honeycomb.WithDebugEnabled())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -39,7 +39,7 @@ func main() {
 	flag.Parse()
 
 	exporter, err := honeycomb.NewExporter(honeycomb.Config{
-		ApiKey:      *apikey,
+		APIKey:      *apikey,
 		Dataset:     *dataset,
 		Debug:       true,
 		ServiceName: "opentelemetry-client",

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -39,8 +39,9 @@ func main() {
 	flag.Parse()
 
 	exporter, err := honeycomb.NewExporter(
-		honeycomb.Config{},
-		honeycomb.UsingAPIKey(*apikey),
+		honeycomb.Config{
+			APIKey: *apikey,
+		},
 		honeycomb.TargetingDataset(*dataset),
 		honeycomb.WithServiceName("opentelemetry-client"),
 		honeycomb.WithDebugEnabled())

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -47,8 +47,9 @@ func main() {
 	flag.Parse()
 
 	exporter, err := honeycomb.NewExporter(
-		honeycomb.Config{},
-		honeycomb.UsingAPIKey(*apikey),
+		honeycomb.Config{
+			APIKey: *apikey,
+		},
 		honeycomb.TargetingDataset(*dataset),
 		honeycomb.WithServiceName("opentelemetry-server"),
 		honeycomb.WithDebugEnabled())

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -47,7 +47,7 @@ func main() {
 	flag.Parse()
 
 	exporter, err := honeycomb.NewExporter(honeycomb.Config{
-		ApiKey:      *apikey,
+		APIKey:      *apikey,
 		Dataset:     *dataset,
 		Debug:       true,
 		ServiceName: "opentelemetry-server",

--- a/example/server/server.go
+++ b/example/server/server.go
@@ -46,12 +46,12 @@ func main() {
 	dataset := flag.String("dataset", "opentelemetry", "Your Honeycomb dataset")
 	flag.Parse()
 
-	exporter, err := honeycomb.NewExporter(honeycomb.Config{
-		APIKey:      *apikey,
-		Dataset:     *dataset,
-		Debug:       true,
-		ServiceName: "opentelemetry-server",
-	})
+	exporter, err := honeycomb.NewExporter(
+		honeycomb.Config{},
+		honeycomb.UsingAPIKey(*apikey),
+		honeycomb.TargetingDataset(*dataset),
+		honeycomb.WithServiceName("opentelemetry-server"),
+		honeycomb.WithDebugEnabled())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870 // indirect
+	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/honeycombio/libhoney-go v1.12.0
 	github.com/klauspost/compress v1.9.0 // indirect

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -18,6 +18,8 @@ package honeycomb
 import (
 	"context"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -29,14 +31,17 @@ import (
 )
 
 const (
-	defaultApiKey  = "apikey-placeholder"
+	defaultAPIKey  = "apikey-placeholder"
 	defaultDataset = "opentelemetry"
 )
 
+// Config defines the basic configuration for the Honeycomb exporter.
 type Config struct {
-	// ApiKey is your Honeycomb authentication token, available from
+	// APIKey is your Honeycomb authentication token, available from
 	// https://ui.honeycomb.io/account. default: apikey-placeholder
-	ApiKey string
+	//
+	// Don't have a Honeycomb account? Sign up at https://ui.honeycomb.io/signup
+	APIKey string
 	// Dataset is the name of the Honeycomb dataset to which events will be
 	// sent. default: beeline-go
 	Dataset string
@@ -59,6 +64,152 @@ type Config struct {
 	OnError func(err error)
 }
 
+type exporterConfig struct {
+	staticFields  map[string]interface{}
+	dynamicFields map[string]func() interface{}
+	output        libhoney.Output
+}
+
+const (
+	expectedStaticFieldCount  = 8
+	expectedDynamicFieldCount = 4
+)
+
+// ExporterOption is an optional change to the configuration used by the
+// NewExporter function.
+type ExporterOption func(*exporterConfig) error
+
+func validateField(name string) error {
+	if len(name) == 0 {
+		return errors.New("field name must not be empty")
+	}
+	return nil
+}
+
+// WithField adds a field with the given name and value to the exporter. Any
+// events published by this exporter will include this field.
+//
+// This function replaces any field registered previously with the same name.
+func WithField(name string, value interface{}) ExporterOption {
+	return func(c *exporterConfig) error {
+		if err := validateField(name); err != nil {
+			return err
+		}
+		if c.staticFields == nil {
+			c.staticFields = make(map[string]interface{}, expectedStaticFieldCount)
+		}
+		c.staticFields[name] = value
+		if c.dynamicFields != nil {
+			delete(c.dynamicFields, name)
+		}
+		return nil
+	}
+}
+
+// WithFields adds a set of fields to the exporter. Any events published by this
+// exporter will include fields pairing each name in the given map with its
+// corresponding value.
+//
+// This function replaces any field registered previously with the same name.
+func WithFields(m map[string]interface{}) ExporterOption {
+	return func(c *exporterConfig) error {
+		count := len(m)
+		if count == 0 {
+			return nil
+		}
+		if c.staticFields == nil {
+			if count < expectedStaticFieldCount {
+				count = expectedStaticFieldCount
+			}
+			c.staticFields = make(map[string]interface{}, count)
+		}
+		for name, value := range m {
+			if err := validateField(name); err != nil {
+				return err
+			}
+			c.staticFields[name] = value
+		}
+		if c.dynamicFields != nil {
+			for name := range m {
+				delete(c.dynamicFields, name)
+			}
+		}
+		return nil
+	}
+}
+
+func validateDynamicField(name string, f func() interface{}) error {
+	if len(name) == 0 {
+		return errors.New("dynamic field name must not be empty")
+	}
+	if f == nil {
+		return fmt.Errorf("dynamic field %q must have a non-nil function", name)
+	}
+	return nil
+}
+
+// WithDynamicField adds a dynamic field with the given name to the
+// exporter. Any events published by this exporter will include a field with the
+// given name and a value supplied by invoking the corresponding function.
+//
+// This function replaces any field registered previously with the same name.
+func WithDynamicField(name string, f func() interface{}) ExporterOption {
+	return func(c *exporterConfig) error {
+		if err := validateDynamicField(name, f); err != nil {
+			return err
+		}
+		if c.dynamicFields == nil {
+			c.dynamicFields = make(map[string]func() interface{}, expectedDynamicFieldCount)
+		}
+		c.dynamicFields[name] = f
+		if c.staticFields != nil {
+			delete(c.staticFields, name)
+		}
+		return nil
+	}
+}
+
+// WithDynamicFields adds a set of dynamic fields to the exporter. Any events
+// published by this exporter will include fields pairing each name in the given
+// map with a value supplied by invoking the corresponding function.
+//
+// This function replaces any field registered previously with the same name.
+func WithDynamicFields(m map[string]func() interface{}) ExporterOption {
+	return func(c *exporterConfig) error {
+		count := len(m)
+		if count == 0 {
+			return nil
+		}
+		if c.dynamicFields == nil {
+			if count < expectedDynamicFieldCount {
+				count = expectedDynamicFieldCount
+			}
+			c.dynamicFields = make(map[string]func() interface{}, count)
+		}
+		for name, f := range m {
+			if err := validateDynamicField(name, f); err != nil {
+				return err
+			}
+			c.dynamicFields[name] = f
+		}
+		if c.staticFields != nil {
+			for name := range m {
+				delete(c.staticFields, name)
+			}
+		}
+		return nil
+	}
+}
+
+// withHoneycombOutput sets the event output handler on the Honeycomb event
+// transmission subsystem.
+func withHoneycombOutput(o libhoney.Output) ExporterOption {
+	return func(c *exporterConfig) error {
+		c.output = o
+		return nil
+	}
+}
+
 // Exporter is an implementation of trace.Exporter that uploads a span to Honeycomb.
 type Exporter struct {
 	builder *libhoney.Builder
@@ -73,35 +224,25 @@ type Exporter struct {
 	onError func(err error)
 }
 
-// SpanEvent represents an event attached to a specific span.
-type SpanEvent struct {
+var _ trace.SpanSyncer = (*Exporter)(nil)
+
+// spanEvent represents an event attached to a specific span.
+type spanEvent struct {
 	Name     string `json:"name"`
 	TraceID  string `json:"trace.trace_id"`
 	ParentID string `json:"trace.parent_id,omitempty"`
 	SpanType string `json:"meta.span_type"`
 }
 
-type SpanRefType int64
+type spanRefType int64
 
 const (
-	SpanRefType_CHILD_OF     SpanRefType = 0
-	SpanRefType_FOLLOWS_FROM SpanRefType = 1
+	spanRefTypeChildOf     spanRefType = 0
+	spanRefTypeFollowsFrom spanRefType = 1
 )
 
-// Link represents a link to a trace and span that lives elsewhere.
-// TraceID and ParentID are used to identify the span with which the trace is associated
-// We are modeling Links for now as child spans rather than properties of the event.
-type Link struct {
-	TraceID     string      `json:"trace.trace_id"`
-	ParentID    string      `json:"trace.parent_id,omitempty"`
-	LinkTraceID string      `json:"trace.link.trace_id"`
-	LinkSpanID  string      `json:"trace.link.span_id"`
-	SpanType    string      `json:"meta.span_type"`
-	RefType     SpanRefType `json:"ref_type,omitempty"`
-}
-
-// Span is the format of trace events that Honeycomb accepts
-type Span struct {
+// span is the format of trace events that Honeycomb accepts.
+type span struct {
 	TraceID         string  `json:"trace.trace_id"`
 	Name            string  `json:"name"`
 	ID              string  `json:"trace.span_id"`
@@ -120,145 +261,10 @@ func getHoneycombTraceID(traceID string) string {
 	return hcTraceUUID.String()
 }
 
-// Close waits for all in-flight messages to be sent. You should
-// call Close() before app termination.
-func (e *Exporter) Close() {
-	libhoney.Close()
-}
-
-// NewExporter returns an implementation of trace.Exporter that uploads spans to Honeycomb
-//
-// apiKey is your Honeycomb apiKey (also known as your write key)
-// dataset is the name of your Honeycomb dataset
-//
-// Don't have a Honeycomb account? Sign up at https://ui.honeycomb.io/signup
-func NewExporter(config Config) (*Exporter, error) {
-	// Developer note: bump this with each release
-	versionStr := "0.2.1"
-
-	if config.UserAgent != "" {
-		libhoney.UserAgentAddition = config.UserAgent + "/" + versionStr
-	} else {
-		libhoney.UserAgentAddition = "Honeycomb-OpenTelemetry-exporter/" + versionStr
-	}
-
-	if config.ApiKey == "" {
-		config.ApiKey = defaultApiKey
-	}
-	if config.Dataset == "" {
-		config.Dataset = defaultDataset
-	}
-
-	libhoneyConfig := libhoney.Config{
-		WriteKey: config.ApiKey,
-		Dataset:  config.Dataset,
-	}
-	if config.Debug {
-		libhoneyConfig.Logger = &libhoney.DefaultLogger{}
-	}
-	if config.APIHost != "" {
-		libhoneyConfig.APIHost = config.APIHost
-	}
-
-	err := libhoney.Init(libhoneyConfig)
-	if err != nil {
-		return nil, err
-	}
-	builder := libhoney.NewBuilder()
-
-	onError := func(err error) {
-		if config.OnError != nil {
-			config.OnError(err)
-			return
-		}
-		log.Printf("Error when sending spans to Honeycomb: %v", err)
-	}
-
-	return &Exporter{
-		builder:     builder,
-		serviceName: config.ServiceName,
-		onError:     onError,
-	}, nil
-}
-
-// ExportSpan exports a SpanData to Honeycomb.
-func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
-	ev := e.builder.NewEvent()
-
-	if e.serviceName != "" {
-		ev.AddField("service_name", e.serviceName)
-	}
-
-	ev.Timestamp = data.StartTime
-	hs := honeycombSpan(data)
-	ev.Add(hs)
-
-	// We send these message events as 0 duration spans
-	for _, a := range data.MessageEvents {
-		spanEv := e.builder.NewEvent()
-		if e.serviceName != "" {
-			spanEv.AddField("service_name", e.serviceName)
-		}
-
-		for _, kv := range a.Attributes {
-			spanEv.AddField(string(kv.Key), kv.Value.Emit())
-		}
-		spanEv.Timestamp = a.Time
-
-		spanEv.Add(SpanEvent{
-			Name:     a.Name,
-			TraceID:  getHoneycombTraceID(data.SpanContext.TraceIDString()),
-			ParentID: data.SpanContext.SpanIDString(),
-			SpanType: "span_event",
-		})
-		err := spanEv.Send()
-		if err != nil {
-			e.onError(err)
-		}
-	}
-
-	for _, link := range data.Links {
-		linkEv := e.builder.NewEvent()
-		linkEv.Add(Link{
-			TraceID:     getHoneycombTraceID(data.SpanContext.TraceIDString()),
-			ParentID:    data.SpanContext.SpanIDString(),
-			LinkTraceID: getHoneycombTraceID(link.TraceIDString()),
-			LinkSpanID:  link.SpanIDString(),
-			SpanType:    "link",
-			// TODO(akvanhar): properly set the reference type when specs are defined
-			// see https://github.com/open-telemetry/opentelemetry-specification/issues/65
-			RefType: SpanRefType_CHILD_OF,
-
-			// TODO(akvanhar) add support for link.Attributes
-		})
-		err := linkEv.Send()
-		if err != nil {
-			e.onError(err)
-		}
-	}
-
-	for _, kv := range data.Attributes {
-		ev.AddField(string(kv.Key), kv.Value.AsInterface())
-	}
-
-	ev.AddField("status.code", int32(data.Status))
-	// If the status isn't zero, set error to be true
-	if data.Status != 0 {
-		ev.AddField("error", true)
-	}
-
-	err := ev.SendPresampled()
-	if err != nil {
-		e.onError(err)
-	}
-}
-
-var _ trace.SpanSyncer = (*Exporter)(nil)
-
-func honeycombSpan(s *trace.SpanData) *Span {
+func honeycombSpan(s *trace.SpanData) *span {
 	sc := s.SpanContext
 
-	hcSpan := &Span{
+	hcSpan := &span{
 		TraceID:         getHoneycombTraceID(sc.TraceIDString()),
 		ID:              sc.SpanIDString(),
 		Name:            s.Name,
@@ -278,4 +284,155 @@ func honeycombSpan(s *trace.SpanData) *Span {
 		hcSpan.Error = true
 	}
 	return hcSpan
+}
+
+// NewExporter returns an implementation of trace.Exporter that uploads spans to Honeycomb.
+func NewExporter(config Config, opts ...ExporterOption) (*Exporter, error) {
+	// Developer note: bump this with each release
+	// TODO: Stamp this via a variable set at link time with a value derived
+	// from the current VCS tag.
+	const versionStr = "0.2.1"
+	if config.UserAgent != "" {
+		libhoney.UserAgentAddition = config.UserAgent + "/" + versionStr
+	} else {
+		libhoney.UserAgentAddition = "Honeycomb-OpenTelemetry-exporter/" + versionStr
+	}
+
+	if len(config.APIKey) == 0 {
+		config.APIKey = defaultAPIKey
+	}
+	if len(config.Dataset) == 0 {
+		config.Dataset = defaultDataset
+	}
+	econf := exporterConfig{}
+	for _, o := range opts {
+		if err := o(&econf); err != nil {
+			return nil, err
+		}
+	}
+
+	libhoneyConfig := libhoney.Config{
+		WriteKey: config.APIKey,
+		Dataset:  config.Dataset,
+	}
+	if config.Debug {
+		libhoneyConfig.Logger = &libhoney.DefaultLogger{}
+	}
+	if len(config.APIHost) != 0 {
+		libhoneyConfig.APIHost = config.APIHost
+	}
+	if econf.output != nil {
+		libhoneyConfig.Output = econf.output
+	}
+
+	if err := libhoney.Init(libhoneyConfig); err != nil {
+		return nil, err
+	}
+	builder := libhoney.NewBuilder()
+
+	for name, value := range econf.staticFields {
+		builder.AddField(name, value)
+	}
+	for name, f := range econf.dynamicFields {
+		builder.AddDynamicField(name, f)
+	}
+
+	onError := config.OnError
+	if onError == nil {
+		onError = func(err error) {
+			log.Printf("Error when sending spans to Honeycomb: %v", err)
+		}
+	}
+
+	return &Exporter{
+		builder:     builder,
+		serviceName: config.ServiceName,
+		onError:     onError,
+	}, nil
+}
+
+// ExportSpan exports a SpanData to Honeycomb.
+func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
+	ev := e.builder.NewEvent()
+
+	if len(e.serviceName) != 0 {
+		ev.AddField("service_name", e.serviceName)
+	}
+
+	ev.Timestamp = data.StartTime
+	ev.Add(honeycombSpan(data))
+
+	// We send these message events as zero-duration spans.
+	for _, a := range data.MessageEvents {
+		spanEv := e.builder.NewEvent()
+		if len(e.serviceName) != 0 {
+			spanEv.AddField("service_name", e.serviceName)
+		}
+
+		for _, kv := range a.Attributes {
+			spanEv.AddField(string(kv.Key), kv.Value.Emit())
+		}
+		spanEv.Timestamp = a.Time
+
+		spanEv.Add(spanEvent{
+			Name:     a.Name,
+			TraceID:  getHoneycombTraceID(data.SpanContext.TraceIDString()),
+			ParentID: data.SpanContext.SpanIDString(),
+			SpanType: "span_event",
+		})
+		if err := spanEv.Send(); err != nil {
+			e.onError(err)
+		}
+	}
+
+	// link represents a link to a trace and span that lives elsewhere.
+	// TraceID and ParentID are used to identify the span with which the trace is associated
+	// We are modeling Links for now as child spans rather than properties of the event.
+	type link struct {
+		TraceID     string      `json:"trace.trace_id"`
+		ParentID    string      `json:"trace.parent_id,omitempty"`
+		LinkTraceID string      `json:"trace.link.trace_id"`
+		LinkSpanID  string      `json:"trace.link.span_id"`
+		SpanType    string      `json:"meta.span_type"`
+		RefType     spanRefType `json:"ref_type,omitempty"`
+	}
+
+	for _, spanLink := range data.Links {
+		linkEv := e.builder.NewEvent()
+		linkEv.Add(link{
+			TraceID:     getHoneycombTraceID(data.SpanContext.TraceIDString()),
+			ParentID:    data.SpanContext.SpanIDString(),
+			LinkTraceID: getHoneycombTraceID(spanLink.TraceIDString()),
+			LinkSpanID:  spanLink.SpanIDString(),
+			SpanType:    "link",
+			// TODO(akvanhar): properly set the reference type when specs are defined
+			// see https://github.com/open-telemetry/opentelemetry-specification/issues/65
+			RefType: spanRefTypeChildOf,
+
+			// TODO(akvanhar) add support for link.Attributes
+		})
+		if err := linkEv.Send(); err != nil {
+			e.onError(err)
+		}
+	}
+
+	for _, kv := range data.Attributes {
+		ev.AddField(string(kv.Key), kv.Value.AsInterface())
+	}
+
+	ev.AddField("status.code", int32(data.Status))
+	// If the status isn't zero, set error to be true.
+	if data.Status != 0 {
+		ev.AddField("error", true)
+	}
+
+	if err := ev.SendPresampled(); err != nil {
+		e.onError(err)
+	}
+}
+
+// Close waits for all in-flight messages to be sent. You should
+// call Close() before app termination.
+func (e *Exporter) Close() {
+	libhoney.Close()
 }

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -3,10 +3,11 @@ package honeycomb
 import (
 	"context"
 	"encoding/hex"
-	"github.com/google/uuid"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/api/core"
@@ -126,13 +127,16 @@ func setUpTestExporter(mockHoneycomb *libhoney.MockOutput) (apitrace.Tracer, err
 		Dataset:     "overridden",
 		ServiceName: "opentelemetry-test",
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	libhoney.Init(libhoney.Config{
 		WriteKey: "test",
 		Dataset:  "test",
 		Output:   mockHoneycomb,
 	})
-	exporter.Builder = libhoney.NewBuilder()
+	exporter.builder = libhoney.NewBuilder()
 
 	tp, err := sdktrace.NewProvider(sdktrace.WithConfig(sdktrace.Config{DefaultSampler: sdktrace.AlwaysSample()}),
 		sdktrace.WithSyncer(exporter))

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -125,12 +125,12 @@ func TestExport(t *testing.T) {
 
 func setUpTestExporter(mockHoneycomb *libhoney.MockOutput, opts ...ExporterOption) (apitrace.Tracer, error) {
 	exporter, err := NewExporter(
-		Config{
-			APIKey:      "overridden",
-			Dataset:     "test",
-			ServiceName: "opentelemetry-test",
-		},
-		append(opts, withHoneycombOutput(mockHoneycomb))...)
+		Config{},
+		append(opts,
+			UsingAPIKey("overridden"),
+			TargetingDataset("test"),
+			WithServiceName("opentelemetry-test"),
+			withHoneycombOutput(mockHoneycomb))...)
 	if err != nil {
 		return nil, err
 	}

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -6,12 +6,12 @@ import (
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"go.opentelemetry.io/otel/sdk/export/trace"
 	"go.opentelemetry.io/otel/api/core"
 	apitrace "go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/sdk/export/trace"
 )
 
-// Create a Golang time.Time from a Google protobuf Timestamp.
+// TimestampToTime creates a Go time.Time value from a Google protobuf Timestamp.
 func TimestampToTime(ts *timestamp.Timestamp) (t time.Time) {
 	if ts == nil {
 		return
@@ -19,33 +19,32 @@ func TimestampToTime(ts *timestamp.Timestamp) (t time.Time) {
 	return time.Unix(ts.Seconds, int64(ts.Nanos))
 }
 
-
 // Get SpanKind from an OC Span_SpanKind
 func oTelSpanKind(kind tracepb.Span_SpanKind) apitrace.SpanKind {
 	// note that tracepb.SpanKindInternal, tracepb.SpanKindProducer and tracepb.SpanKindConsumer
 	// have no equivalent OC proto type.
 	switch kind {
-		case tracepb.Span_SPAN_KIND_UNSPECIFIED:
-			return apitrace.SpanKindUnspecified
-		case tracepb.Span_SERVER:
-			return apitrace.SpanKindServer
-		case tracepb.Span_CLIENT:
-			return apitrace.SpanKindClient
-		default:
-			return apitrace.SpanKindUnspecified
+	case tracepb.Span_SPAN_KIND_UNSPECIFIED:
+		return apitrace.SpanKindUnspecified
+	case tracepb.Span_SERVER:
+		return apitrace.SpanKindServer
+	case tracepb.Span_CLIENT:
+		return apitrace.SpanKindClient
+	default:
+		return apitrace.SpanKindUnspecified
 	}
 }
 
 // Creates an OpenTelemetry SpanContext from information in an OC Span.
-// Note that the OC Span has no equivalent to TraceFlags field in the 
+// Note that the OC Span has no equivalent to TraceFlags field in the
 // OpenTelemetry SpanContext type.
-func spanContext(traceId []byte, spanId []byte) core.SpanContext {
+func spanContext(traceID []byte, spanID []byte) core.SpanContext {
 	ctx := core.SpanContext{}
-	if traceId != nil {
-		copy(ctx.TraceID[:], traceId[:])
+	if traceID != nil {
+		copy(ctx.TraceID[:], traceID[:])
 	}
-	if spanId != nil {
-		copy(ctx.SpanID[:], spanId[:])
+	if spanID != nil {
+		copy(ctx.SpanID[:], spanID[:])
 	}
 	return ctx
 }
@@ -74,7 +73,7 @@ func createOTelAttributes(attributes *tracepb.Span_Attributes) []core.KeyValue {
 			keyValue.Value = core.Float64(value.DoubleValue)
 		}
 		oTelAttrs[i] = keyValue
-		i += 1
+		i++
 	}
 
 	return oTelAttrs
@@ -91,7 +90,7 @@ func createSpanLinks(spanLinks *tracepb.Span_Links) []apitrace.Link {
 	for i, link := range spanLinks.Link {
 		traceLink := apitrace.Link{
 			SpanContext: spanContext(link.GetTraceId(), link.GetSpanId()),
-			Attributes: createOTelAttributes(link.Attributes),
+			Attributes:  createOTelAttributes(link.Attributes),
 		}
 		links[i] = traceLink
 	}
@@ -106,7 +105,6 @@ func attributeValueAsString(val *tracepb.AttributeValue) string {
 
 	return ""
 }
-
 
 func getDroppedLinkCount(links *tracepb.Span_Links) int {
 	if links != nil {
@@ -132,7 +130,7 @@ func getSpanName(span *tracepb.Span) string {
 	return ""
 }
 
-// Convert an OC Span to an OTel SpanData
+// OCProtoSpanToOTelSpanData converts an OC Span to an OTel SpanData.
 func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	if span == nil {
 		return nil, errors.New("expected a non-nil span")
@@ -155,5 +153,3 @@ func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 
 	return spanData, nil
 }
-
-


### PR DESCRIPTION
Migrate optional configuration fields to functional options, making it more clear what's required to create a functional `honeycomb.Exporter`.

Accommodate both static and dynamic global event fields—analogous to `libhoney.Client`'s `AddField` and `AddDynamicField` methods and the `libhoney.AddField` and `libhoney.AddDynamicField` functions—with the following new functional options accepted by the `NewExporter` function:
- `WithField`  
  (A single field with a static value.)
- `WithFields`  
  (A set of fields with static values.)
- `WithDynamicField`  
  (A single field with a dynamic value.)
- `WithDynamicFields`  
  (A set of fields with dynamic values.)

Since this module remains well ahead of a major version release, **this patch includes incompatible changes**, removing several exported types and fields in the interest of retaining freedom to change more of these internal details in the future.

*Up for debate:* Is it worth keeping the `Config` struct type, whittled down now to a single required field? If we eliminate the struct and instead have `NewExporter` accept a string for the API key as the first parameter, but then later decide to add more required parameters, we'd have to change the signature of `NewExporter`. Alternately, we'd have to add fields to `Config`. I prefer using individual parameters for this, but when several of the same type occur together, it can then be hard to discern which parameter means what.

Fixes #52.