### PR TITLE
Adding translator to create OTel SDK Spans from OC Proto Spans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/DataDog/zstd v1.4.1 // indirect
+	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
 	github.com/facebookgo/ensure v0.0.0-20160127193407-b4ab57deab51 // indirect
 	github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bombsimon/wsl v1.2.5 h1:9gTOkIwVtoDZywvX802SDHokeX4kW1cKnV8ZTVAPkRs=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -51,6 +51,8 @@ type Config struct {
 	// APIHost is the hostname for the Honeycomb API server to which to send
 	// these events. default: https://api.honeycomb.io/
 	APIHost string
+	// UserAgent will set the user agent used by the exporter
+	UserAgent string
 	// OnError is the hook to be called when there is
 	// an error occurred when uploading the span data.
 	// If no custom hook is set, errors are logged.
@@ -137,7 +139,12 @@ func (e *Exporter) Close() {
 func NewExporter(config Config) (*Exporter, error) {
 	// Developer note: bump this with each release
 	versionStr := "0.2.1"
-	libhoney.UserAgentAddition = "Honeycomb-OpenTelemetry-exporter/" + versionStr
+
+	if config.UserAgent != "" {
+		libhoney.UserAgentAddition = config.UserAgent + "/" + versionStr
+	} else {
+		libhoney.UserAgentAddition = "Honeycomb-OpenTelemetry-exporter/" + versionStr
+	}
 
 	if config.ApiKey == "" {
 		config.ApiKey = defaultApiKey

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -58,6 +58,7 @@ func createOTelAttributes(attributes *tracepb.Span_Attributes) []core.KeyValue {
 
 	oTelAttrs := make([]core.KeyValue, len(attributes.AttributeMap))
 
+	i := 0
 	for key, attributeValue := range attributes.AttributeMap {
 		keyValue := core.KeyValue{
 			Key: core.Key(key),
@@ -72,7 +73,8 @@ func createOTelAttributes(attributes *tracepb.Span_Attributes) []core.KeyValue {
 		case *tracepb.AttributeValue_DoubleValue:
 			keyValue.Value = core.Float64(value.DoubleValue)
 		}
-		oTelAttrs = append(oTelAttrs, keyValue)
+		oTelAttrs[i] = keyValue
+		i += 1
 	}
 
 	return oTelAttrs
@@ -86,12 +88,12 @@ func createSpanLinks(spanLinks *tracepb.Span_Links) []apitrace.Link {
 
 	links := make([]apitrace.Link, len(spanLinks.Link))
 
-	for _, link := range spanLinks.Link {
+	for i, link := range spanLinks.Link {
 		traceLink := apitrace.Link{
 			SpanContext: spanContext(link.GetTraceId(), link.GetSpanId()),
 			Attributes: createOTelAttributes(link.Attributes),
 		}
-		links = append(links, traceLink)
+		links[i] = traceLink
 	}
 
 	return links

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -122,6 +122,14 @@ func getChildSpanCount(span *tracepb.Span) int {
 	return 0
 }
 
+func getSpanName(span *tracepb.Span) string {
+	if name := span.GetName(); name != nil {
+		return name.GetValue()
+	}
+
+	return ""
+}
+
 // Convert an OC Span to an OTel SpanData
 func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	if span == nil {
@@ -133,6 +141,7 @@ func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	}
 
 	copy(spanData.ParentSpanID[:], span.GetParentSpanId()[:])
+	spanData.Name = getSpanName(span)
 	spanData.SpanKind = oTelSpanKind(span.GetKind())
 	spanData.ChildSpanCount = int(span.GetChildSpanCount().GetValue())
 	spanData.Links = createSpanLinks(span.GetLinks())

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -1,0 +1,128 @@
+package honeycomb
+
+import (
+	"errors"
+	"time"
+
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/api/core"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+)
+
+func TimestampToTime(ts *timestamp.Timestamp) (t time.Time) {
+	if ts == nil {
+		return
+	}
+	return time.Unix(ts.Seconds, int64(ts.Nanos))
+}
+
+
+func copySpanKind(sd *trace.SpanData, kind tracepb.Span_SpanKind) {
+	// note that tracepb.SpanKindInternal, tracepb.SpanKindProducer and tracepb.SpanKindConsumer
+	// have no equivalent OC proto type.
+	switch kind {
+		case tracepb.Span_SPAN_KIND_UNSPECIFIED:
+			sd.SpanKind = apitrace.SpanKindUnspecified
+		case tracepb.Span_SERVER:
+			sd.SpanKind = apitrace.SpanKindServer
+		case tracepb.Span_CLIENT:
+			sd.SpanKind = apitrace.SpanKindClient
+		default:
+			sd.SpanKind = apitrace.SpanKindUnspecified
+	}
+}
+
+// Creates an OpenTelemetry SpanContext from information in an OC Span.
+// Note that the OC Span has no equivalent to TraceFlags field in the 
+// OpenTelemetry SpanContext type.
+func spanContext(traceId []byte, spanId []byte) core.SpanContext {
+	ctx := core.SpanContext{}
+	if traceId != nil {
+		copy(ctx.TraceID[:], traceId[:])
+	}
+	if spanId != nil {
+		copy(ctx.SpanID[:], spanId[:])
+	}
+	return ctx
+}
+
+func copySpanAttributes(fromSpan *tracepb.Span, toSpan *trace.SpanData) {
+	if fromSpan.Attributes != nil {
+		if fromSpan.Attributes.AttributeMap != nil {
+			toSpan.Attributes = make([]core.KeyValue, len(fromSpan.Attributes.AttributeMap))
+			for key, value := range fromSpan.Attributes.AttributeMap {
+				keyValue := core.KeyValue{
+					Key: core.Key(key),
+					// TODO(posman): handle non-string values
+					Value: core.String(value.GetStringValue().GetValue()),
+				}
+				toSpan.Attributes = append(toSpan.Attributes, keyValue)
+			}
+		}
+	}
+}
+
+func copySpanLinks(fromSpan *tracepb.Span, toSpan *trace.SpanData) {
+	if fromSpan.Links == nil {
+		return
+	}
+
+	toSpan.Links = make([]apitrace.Link, len(fromSpan.Links.Link))
+
+	for _, link := range fromSpan.Links.Link {
+		traceLink := apitrace.Link{
+			SpanContext: spanContext(link.TraceId, link.SpanId),
+		}
+
+		if link.Attributes != nil {
+			if link.Attributes.AttributeMap != nil {
+				traceLink.Attributes = make([]core.KeyValue, len(link.Attributes.AttributeMap))
+				for key, value := range link.Attributes.AttributeMap {
+					keyValue := core.KeyValue{
+						Key: core.Key(key),
+						// TODO(posman): handle non-string values
+						Value: core.String(value.GetStringValue().GetValue()),
+					}
+					traceLink.Attributes = append(traceLink.Attributes, keyValue)
+				}
+			}
+		}
+
+		toSpan.Links = append(toSpan.Links, traceLink)
+	}
+
+	toSpan.DroppedLinkCount = int(fromSpan.Links.DroppedLinksCount)
+}
+
+func ProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
+	if span == nil {
+		return nil, errors.New("expected a non-nil span")
+	}
+
+	spanData := &trace.SpanData{
+		SpanContext: spanContext(span.TraceId, span.SpanId),
+	}
+
+	// Copy ParentSpanID, Span Kind and ChildSpanCount
+	copy(spanData.ParentSpanID[:], span.ParentSpanId[:])
+	copySpanKind(spanData, span.Kind)
+	spanData.ChildSpanCount = int(span.ChildSpanCount.GetValue())
+	copySpanLinks(span, spanData)
+	copySpanAttributes(span, spanData)
+
+	spanData.StartTime = TimestampToTime(span.StartTime)
+	spanData.EndTime = TimestampToTime(span.EndTime)
+
+	// TODO(posman)
+	//	MessageEvents []Event = span.TimeEvents *Span_TimeEvents ????
+	//	Status codes.Code = span.Status *Status
+	//	HasRemoteParent bool = ! span.SameProcessAsParentSpan *wrappers.BoolValue
+	//	DroppedAttributeCount int = ???
+	//	DroppedMessageEventCount int = ???
+
+	return spanData, nil
+}
+
+


### PR DESCRIPTION
The OpenTelemetry collector exports trace data to exporters as a [TraceData](https://godoc.org/github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata#TraceData) struct. In order to reuse the `ExportSpan` function in the SDK exporter, we'll need to convert these to [SpanData](https://godoc.org/go.opentelemetry.io/otel/sdk/export/trace#SpanData) structs. This PR adds a translators file to the opentelemetry-exporter-go package with a single exported function, `OCProtoSpanToOtelSpanData` that the collector will use to do the conversion.

Also making the UserAgent string used by `libhoney-go` configurable so that we can distinguish OpenTelemetry exporter events from OpenTelemetry collector events. 

See [relevant code in collector exporter](https://github.com/honeycombio/opentelemetry-collector-contrib/blob/honeycomb-exporter/exporter/honeycombexporter/honeycomb.go#L49) for context. 