### PR TITLE
Add support for HasRemoteParent, Status and MessageEvents to OC proto translator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/golang/protobuf v1.3.5
+	github.com/google/go-cmp v0.4.0
 	github.com/google/uuid v1.1.1
 	github.com/honeycombio/libhoney-go v1.12.3
 	github.com/stretchr/testify v1.5.1

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -166,7 +166,7 @@ func getHasRemoteParent(span *tracepb.Span) bool {
 	return false
 }
 
-func getStatus(span *tracepb.Span) codes.Code {
+func getStatusCode(span *tracepb.Span) codes.Code {
 	if span.Status != nil {
 		return codes.Code(span.Status.Code)
 	}
@@ -192,7 +192,7 @@ func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	spanData.MessageEvents = createMessageEvents(span.GetTimeEvents())
 	spanData.StartTime = timestampToTime(span.GetStartTime())
 	spanData.EndTime = timestampToTime(span.GetEndTime())
-	spanData.Status = getStatus(span)
+	spanData.StatusCode = getStatusCode(span)
 	spanData.HasRemoteParent = getHasRemoteParent(span)
 	spanData.DroppedLinkCount = getDroppedLinkCount(span.GetLinks())
 	spanData.ChildSpanCount = getChildSpanCount(span)

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -2,6 +2,7 @@ package honeycomb
 
 import (
 	"errors"
+	"google.golang.org/grpc/codes"
 	"time"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
@@ -130,6 +131,22 @@ func getSpanName(span *tracepb.Span) string {
 	return ""
 }
 
+func getHasRemoteParent(span *tracepb.Span) bool {
+	if sameProcess := span.GetSameProcessAsParentSpan(); sameProcess != nil {
+		return !sameProcess.Value
+	}
+
+	return false
+}
+
+func getStatus(span *tracepb.Span) codes.Code {
+	if span.Status != nil {
+		return codes.Code(span.Status.Code)
+	}
+
+	return codes.OK
+}
+
 // OCProtoSpanToOTelSpanData converts an OC Span to an OTel SpanData.
 func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	if span == nil {
@@ -143,11 +160,12 @@ func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	copy(spanData.ParentSpanID[:], span.GetParentSpanId()[:])
 	spanData.Name = getSpanName(span)
 	spanData.SpanKind = oTelSpanKind(span.GetKind())
-	spanData.ChildSpanCount = int(span.GetChildSpanCount().GetValue())
 	spanData.Links = createSpanLinks(span.GetLinks())
 	spanData.Attributes = createOTelAttributes(span.GetAttributes())
 	spanData.StartTime = timestampToTime(span.GetStartTime())
 	spanData.EndTime = timestampToTime(span.GetEndTime())
+	spanData.Status = getStatus(span)
+	spanData.HasRemoteParent = getHasRemoteParent(span)
 	spanData.DroppedLinkCount = getDroppedLinkCount(span.GetLinks())
 	spanData.ChildSpanCount = getChildSpanCount(span)
 

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -174,6 +174,18 @@ func getStatusCode(span *tracepb.Span) codes.Code {
 	return codes.OK
 }
 
+func getStatusMessage(span *tracepb.Span) string {
+	if span.Status != nil {
+		if span.Status.Message != "" {
+			return span.Status.Message
+		} else {
+			return codes.Code(span.Status.Code).String()
+		}
+	}
+
+	return codes.OK.String()
+}
+
 // OCProtoSpanToOTelSpanData converts an OC Span to an OTel SpanData.
 func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	if span == nil {
@@ -193,6 +205,7 @@ func OCProtoSpanToOTelSpanData(span *tracepb.Span) (*trace.SpanData, error) {
 	spanData.StartTime = timestampToTime(span.GetStartTime())
 	spanData.EndTime = timestampToTime(span.GetEndTime())
 	spanData.StatusCode = getStatusCode(span)
+	spanData.StatusMessage = getStatusMessage(span)
 	spanData.HasRemoteParent = getHasRemoteParent(span)
 	spanData.DroppedLinkCount = getDroppedLinkCount(span.GetLinks())
 	spanData.ChildSpanCount = getChildSpanCount(span)

--- a/honeycomb/translator_test.go
+++ b/honeycomb/translator_test.go
@@ -132,7 +132,7 @@ func TestOCProtoSpanToOTelSpanData(t *testing.T) {
 				},
 			},
 		},
-		Status:           codes.Unknown,
+		StatusCode:       codes.Unknown,
 		HasRemoteParent:  true,
 		DroppedLinkCount: 2,
 		ChildSpanCount:   5,

--- a/honeycomb/translator_test.go
+++ b/honeycomb/translator_test.go
@@ -97,7 +97,7 @@ func TestOCProtoSpanToOTelSpanData(t *testing.T) {
 				},
 			},
 		},
-		Status:                  &tracepb.Status{Code: int32(codes.Unknown)},
+		Status:                  &tracepb.Status{Code: int32(codes.Unknown), Message: "status message"},
 		SameProcessAsParentSpan: &wrappers.BoolValue{Value: false},
 		ChildSpanCount:          &wrappers.UInt32Value{Value: 5},
 	}
@@ -133,6 +133,7 @@ func TestOCProtoSpanToOTelSpanData(t *testing.T) {
 			},
 		},
 		StatusCode:       codes.Unknown,
+		StatusMessage:    "status message",
 		HasRemoteParent:  true,
 		DroppedLinkCount: 2,
 		ChildSpanCount:   5,

--- a/honeycomb/translator_test.go
+++ b/honeycomb/translator_test.go
@@ -1,0 +1,117 @@
+package honeycomb
+
+import (
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.opentelemetry.io/otel/api/core"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	"go.opentelemetry.io/otel/sdk/export/trace"
+	"google.golang.org/grpc/codes"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestOCProtoSpanToOTelSpanData(t *testing.T) {
+	start := time.Now()
+	end := start.Add(10 * time.Millisecond)
+
+	startTimestamp, err := ptypes.TimestampProto(start)
+	if err != nil {
+		t.Fatalf("failed to convert time to timestamp: %v", err)
+	}
+	endTimestamp, err := ptypes.TimestampProto(end)
+	if err != nil {
+		t.Fatalf("failed to convert time to timestamp: %v", err)
+	}
+
+	span := tracepb.Span{
+		TraceId: []byte{0x02},
+		SpanId: []byte{0x03},
+		ParentSpanId: []byte{0x01},
+		Name: &tracepb.TruncatableString{Value:"trace-name"},
+		Kind: tracepb.Span_CLIENT,
+		StartTime: startTimestamp,
+		EndTime: endTimestamp,
+		Attributes: &tracepb.Span_Attributes{
+			AttributeMap: map[string]*tracepb.AttributeValue{
+				"some-string": {
+					Value: &tracepb.AttributeValue_StringValue{
+						StringValue: &tracepb.TruncatableString{Value:"some-value"},
+					},
+				},
+				"some-double": {
+					Value: &tracepb.AttributeValue_DoubleValue{DoubleValue: math.Pi},
+				},
+				"some-int": {
+					Value: &tracepb.AttributeValue_IntValue{IntValue:42},
+				},
+				"some-boolean": {
+					Value: &tracepb.AttributeValue_BoolValue{BoolValue:true},
+				},
+			},
+		},
+		Links: &tracepb.Span_Links{
+			Link: []*tracepb.Span_Link{
+				{
+					TraceId: []byte{0x04},
+					SpanId:  []byte{0x05},
+					Attributes: &tracepb.Span_Attributes{
+						AttributeMap: map[string]*tracepb.AttributeValue{
+							"e": {
+								Value: &tracepb.AttributeValue_DoubleValue{DoubleValue: math.E},
+							},
+						},
+					},
+				},
+			},
+			DroppedLinksCount: 2,
+		},
+		Status: &tracepb.Status{Code: int32(codes.Unknown)},
+		SameProcessAsParentSpan: &wrappers.BoolValue{Value: false},
+		ChildSpanCount: &wrappers.UInt32Value{Value: 5},
+	}
+
+	want := &trace.SpanData{
+		SpanContext: spanContext([]byte{0x02}, []byte{0x03}),
+		ParentSpanID: core.SpanID{0x01},
+		SpanKind: apitrace.SpanKindClient,
+		Name: "trace-name",
+		StartTime: time.Unix(int64(start.Unix()), int64(start.Nanosecond())),
+		EndTime: time.Unix(int64(end.Unix()), int64(end.Nanosecond())),
+		Attributes: []core.KeyValue{
+			core.Key("some-string").String("some-value"),
+			core.Key("some-double").Float64(math.Pi),
+			core.Key("some-int").Int(42),
+			core.Key("some-boolean").Bool(true),
+		},
+		Links: []apitrace.Link{
+			{
+				SpanContext: spanContext([]byte{0x04}, []byte{0x05}),
+				Attributes: []core.KeyValue{
+					core.Key("e").Float64(math.E),
+				},
+			},
+		},
+		Status: codes.Unknown,
+		HasRemoteParent: true,
+		DroppedLinkCount: 2,
+		ChildSpanCount: 5,
+	}
+
+	got, err := OCProtoSpanToOTelSpanData(&span)
+	if err != nil {
+		t.Fatalf("failed to convert proto span to otel span data: %v", err)
+	}
+
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(core.Value{}), cmpopts.SortSlices(keyValueLess)); diff != "" {
+		t.Errorf("otel span: (-want +got):\n%s", diff)
+	}
+}
+
+func keyValueLess(lhs, rhs core.KeyValue) bool {
+	return lhs.Key < rhs.Key
+}


### PR DESCRIPTION
Adds support for setting:
* HasRemoteParent field from the SameProcessAsParentSpan OC field (inverted)
* Status from the Status.Code OC field
* MessageEvents from OC Annotations

Adds a test case for the translator.