### PR TITLE
Accommodate OpenTelemetry provider resource in Honeycomb events

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -437,7 +437,6 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 	applyResourceAttributes := func(ev *libhoney.Event) {
 		if data.Resource != nil {
 			for _, kv := range data.Resource.Attributes() {
-				// TODO(seh): Should we skip the boxing of values here and use Emit instead?
 				ev.AddField(string(kv.Key), kv.Value.AsInterface())
 			}
 		}
@@ -451,7 +450,7 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 		}
 
 		for _, kv := range a.Attributes {
-			spanEv.AddField(string(kv.Key), kv.Value.Emit())
+			spanEv.AddField(string(kv.Key), kv.Value.AsInterface())
 		}
 		// Treat resource-defined attributes as overlays, taking precedent over any same-keyed
 		// message event attributes. Apply them last.

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -258,7 +258,7 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	assert.Equal("handling this...", msgEventName)
 
 	attribute := mainEventFields["request-handled"]
-	assert.Equal("100", attribute)
+	assert.Equal(int64(100), attribute)
 
 	msgEventTraceID := mainEventFields["trace.trace_id"]
 	assert.Equal(honeycombTranslatedTraceID, msgEventTraceID)

--- a/honeycomb/translator.go
+++ b/honeycomb/translator.go
@@ -2,8 +2,9 @@ package honeycomb
 
 import (
 	"errors"
-	"google.golang.org/grpc/codes"
 	"time"
+
+	"google.golang.org/grpc/codes"
 
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -175,15 +176,14 @@ func getStatusCode(span *tracepb.Span) codes.Code {
 }
 
 func getStatusMessage(span *tracepb.Span) string {
-	if span.Status != nil {
-		if span.Status.Message != "" {
-			return span.Status.Message
-		} else {
-			return codes.Code(span.Status.Code).String()
-		}
+	switch {
+	case span.Status == nil:
+		return codes.OK.String()
+	case span.Status.Message != "":
+		return span.Status.Message
+	default:
+		return codes.Code(span.Status.Code).String()
 	}
-
-	return codes.OK.String()
 }
 
 // OCProtoSpanToOTelSpanData converts an OC Span to an OTel SpanData.


### PR DESCRIPTION
OpenTelemetry providers have [an optional "resource"](https://pkg.go.dev/go.opentelemetry.io/otel@v0.4.2/sdk/trace?tab=doc#Config) defined, with an accompanying set of indelible attributes meant for inclusion in all published spans. These are analogous to _libhoney_'s [client-](https://godoc.org/github.com/honeycombio/libhoney-go#Client.Add) and [builder-level fields](https://godoc.org/github.com/honeycombio/libhoney-go#Builder.Add), but these resource attributes should override any same-keyed attributes set on a particular span.

Export these resources when present, with their attributes overlaying any competing attributes in each span.
