### PR TITLE
Treat OpenTelemetry provider resource attributes as underlays in Honeycomb events

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -432,11 +432,11 @@ func NewExporter(config Config, opts ...ExporterOption) (*Exporter, error) {
 	}, nil
 }
 
-// Consume from the response queue, calling the onError callback when errors
-// are encountered.
+// RunErrorLogger consumes from the response queue, calling the onError callback
+// when errors are encountered.
 //
-// This method will block until the passed context.Context is cancelled, or
-// until exporter.Close is called.
+// This method will block until the passed context.Context is canceled, or until
+// exporter.Close is called.
 func (e *Exporter) RunErrorLogger(ctx context.Context) {
 	responses := libhoney.TxResponses()
 	for {

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -458,13 +458,6 @@ func (e *Exporter) RunErrorLogger(ctx context.Context) {
 func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 	ev := e.builder.NewEvent()
 
-	if len(e.serviceName) != 0 {
-		ev.AddField("service_name", e.serviceName)
-	}
-
-	ev.Timestamp = data.StartTime
-	ev.Add(honeycombSpan(data))
-
 	applyResourceAttributes := func(ev *libhoney.Event) {
 		if data.Resource != nil {
 			for _, kv := range data.Resource.Attributes() {
@@ -473,9 +466,22 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 		}
 	}
 
+	// Treat resource-defined attributes as underlays, with any same-keyed span attributes taking
+	// precedence. Apply them first.
+	applyResourceAttributes(ev)
+	if len(e.serviceName) != 0 {
+		ev.AddField("service_name", e.serviceName)
+	}
+
+	ev.Timestamp = data.StartTime
+	ev.Add(honeycombSpan(data))
+
 	// We send these message events as zero-duration spans.
 	for _, a := range data.MessageEvents {
 		spanEv := e.builder.NewEvent()
+		// Treat resource-defined attributes as underlays, with any same-keyed message event
+		// attributes taking precedence. Apply them first.
+		applyResourceAttributes(spanEv)
 		if len(e.serviceName) != 0 {
 			spanEv.AddField("service_name", e.serviceName)
 		}
@@ -483,9 +489,6 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 		for _, kv := range a.Attributes {
 			spanEv.AddField(string(kv.Key), kv.Value.AsInterface())
 		}
-		// Treat resource-defined attributes as overlays, taking precedent over any same-keyed
-		// message event attributes. Apply them last.
-		applyResourceAttributes(spanEv)
 		spanEv.Timestamp = a.Time
 
 		spanEv.Add(spanEvent{
@@ -533,9 +536,6 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 	for _, kv := range data.Attributes {
 		ev.AddField(string(kv.Key), kv.Value.AsInterface())
 	}
-	// Treat resource-defined attributes as overlays, taking precedent over any same-keyed span
-	// attributes. Apply them last.
-	applyResourceAttributes(ev)
 
 	ev.AddField("status.code", int32(data.StatusCode))
 	ev.AddField("status.message", data.StatusMessage)

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -578,17 +578,17 @@ func TestHoneycombOutputWithResource(t *testing.T) {
 
 	tr, err := setUpTestProvider(exporter,
 		sdktrace.WithResourceAttributes(
-			key.Int64("a", overlay),
-			key.Int64("c", overlay),
+			key.Int64("a", middle),
+			key.Int64("c", middle),
 		))
 
 	ctx, span := tr.Start(context.TODO(), "myTestSpan")
 	assert.Nil(err)
 	span.SetAttributes(
-		key.Int64("a", middle),
-		key.Int64("d", middle),
+		key.Int64("a", overlay),
+		key.Int64("d", overlay),
 	)
-	span.AddEvent(ctx, "something", key.Int64("c", middle))
+	span.AddEvent(ctx, "something", key.Int64("c", overlay))
 	time.Sleep(time.Duration(0.5 * float64(time.Millisecond)))
 
 	span.End()
@@ -596,14 +596,13 @@ func TestHoneycombOutputWithResource(t *testing.T) {
 	assert.Len(mockHoneycomb.Events(), 2)
 
 	mainEventFields := mockHoneycomb.Events()[1].Fields()
-	// TODO(seh): This assumes we preserve the original value type in the Honeycomb field.
 	assert.Equal(int64(overlay), mainEventFields["a"])
 	assert.Equal(int64(underlay), mainEventFields["b"])
-	assert.Equal(int64(overlay), mainEventFields["c"])
-	assert.Equal(int64(middle), mainEventFields["d"])
+	assert.Equal(int64(middle), mainEventFields["c"])
+	assert.Equal(int64(overlay), mainEventFields["d"])
 
 	messageEventFields := mockHoneycomb.Events()[0].Fields()
-	assert.Equal(int64(overlay), messageEventFields["a"])
+	assert.Equal(int64(middle), messageEventFields["a"])
 	assert.Equal(int64(underlay), mainEventFields["b"])
-	assert.Equal(int64(overlay), mainEventFields["c"])
+	assert.Equal(int64(middle), mainEventFields["c"])
 }


### PR DESCRIPTION
Rather than overlaying attributes defined by an OpenTelemetry ["resource"](https://pkg.go.dev/go.opentelemetry.io/otel@v0.4.2/sdk/trace?tab=doc#Config) atop span- and message-level attributes, instead treat the resource attributes as an underlay, establishing default values that are overridden by any spans or messages defining attributes with the same
key.

Note that for Honeycomb, static and dynamic fields defined on the exporter by way of the [`WithField*`](https://godoc.org/github.com/honeycombio/opentelemetry-exporter-go/honeycomb#WithField) and [`WithDynamicField*`](https://godoc.org/github.com/honeycombio/opentelemetry-exporter-go/honeycomb#WithDynamicField) functions sit lower than resource attributes. Message and span attributes trump resource attributes, and resource attributes trump exporter attributes.

NB: This change reverses a decision from #66.