### PR TITLE
Record parent span name attribute on attached span events to ease querying

### DIFF
--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -308,10 +308,11 @@ var _ trace.SpanSyncer = (*Exporter)(nil)
 
 // spanEvent represents an event attached to a specific span.
 type spanEvent struct {
-	Name     string `json:"name"`
-	TraceID  string `json:"trace.trace_id"`
-	ParentID string `json:"trace.parent_id,omitempty"`
-	SpanType string `json:"meta.span_type"`
+	Name       string `json:"name"`
+	TraceID    string `json:"trace.trace_id"`
+	ParentID   string `json:"trace.parent_id,omitempty"`
+	ParentName string `json:"trace.parent_name,omitempty"`
+	SpanType   string `json:"meta.span_type"`
 }
 
 type spanRefType int64
@@ -489,10 +490,11 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 		spanEv.Timestamp = a.Time
 
 		spanEv.Add(spanEvent{
-			Name:     a.Name,
-			TraceID:  getHoneycombTraceID(data.SpanContext.TraceIDString()),
-			ParentID: data.SpanContext.SpanIDString(),
-			SpanType: "span_event",
+			Name:       a.Name,
+			TraceID:    getHoneycombTraceID(data.SpanContext.TraceIDString()),
+			ParentID:   data.SpanContext.SpanIDString(),
+			ParentName: data.Name,
+			SpanType:   "span_event",
 		})
 		if err := spanEv.Send(); err != nil {
 			e.onError(err)

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -539,10 +539,6 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 
 	ev.AddField("status.code", int32(data.StatusCode))
 	ev.AddField("status.message", data.StatusMessage)
-	// If the status isn't zero, set error to be true.
-	if data.StatusCode != codes.OK {
-		ev.AddField("error", true)
-	}
 
 	if err := ev.SendPresampled(); err != nil {
 		e.onError(err)

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -266,6 +266,9 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	msgEventParentID := msgEventFields["trace.parent_id"]
 	assert.Equal(spanID, msgEventParentID)
 
+	msgEventParentName := msgEventFields["trace.parent_name"]
+	assert.Equal("myTestSpan", msgEventParentName)
+
 	msgEventServiceName := msgEventFields["service_name"]
 	assert.Equal("opentelemetry-test", msgEventServiceName)
 

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -229,47 +229,47 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	assert.Len(mockHoneycomb.Events(), 2)
 
 	// Check the fields on the main span event.
-	messageEventFields := mockHoneycomb.Events()[1].Fields()
-	traceID := messageEventFields["trace.trace_id"]
+	mainEventFields := mockHoneycomb.Events()[1].Fields()
+	traceID := mainEventFields["trace.trace_id"]
 	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceIDString())
 	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
 
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
-	spanID := messageEventFields["trace.span_id"]
+	spanID := mainEventFields["trace.span_id"]
 	expectedSpanID := span.SpanContext().SpanIDString()
 	assert.Equal(expectedSpanID, spanID)
 
-	name := messageEventFields["name"]
+	name := mainEventFields["name"]
 	assert.Equal("myTestSpan", name)
 
-	durationMilli := messageEventFields["duration_ms"]
+	durationMilli := mainEventFields["duration_ms"]
 	durationMilliFl, ok := durationMilli.(float64)
 	assert.True(ok)
 	assert.Greater(durationMilliFl, 0.0)
 
-	serviceName := messageEventFields["service_name"]
+	serviceName := mainEventFields["service_name"]
 	assert.Equal("opentelemetry-test", serviceName)
 	assert.Equal(mockHoneycomb.Events()[1].Dataset, "test")
 
 	// Check the fields on the zero-duration Message event.
-	mainEventFields := mockHoneycomb.Events()[0].Fields()
-	msgEventName := mainEventFields["name"]
+	msgEventFields := mockHoneycomb.Events()[0].Fields()
+	msgEventName := msgEventFields["name"]
 	assert.Equal("handling this...", msgEventName)
 
-	attribute := mainEventFields["request-handled"]
+	attribute := msgEventFields["request-handled"]
 	assert.Equal(int64(100), attribute)
 
-	msgEventTraceID := mainEventFields["trace.trace_id"]
+	msgEventTraceID := msgEventFields["trace.trace_id"]
 	assert.Equal(honeycombTranslatedTraceID, msgEventTraceID)
 
-	msgEventParentID := mainEventFields["trace.parent_id"]
+	msgEventParentID := msgEventFields["trace.parent_id"]
 	assert.Equal(spanID, msgEventParentID)
 
-	msgEventServiceName := mainEventFields["service_name"]
+	msgEventServiceName := msgEventFields["service_name"]
 	assert.Equal("opentelemetry-test", msgEventServiceName)
 
-	spanEvent := mainEventFields["meta.span_type"]
+	spanEvent := msgEventFields["meta.span_type"]
 	assert.Equal("span_event", spanEvent)
 }
 


### PR DESCRIPTION
In order to allow easier querying for span events that are attached to spans with particular "name" field values, transcribe the parent span's "name" field value to each child message event's "trace.parent_name" field.

I chose the proposed new event field name to mimic the existing "trace.parent_id" field.