### PR TITLE
Use the newly implemented Stringer interface on the core.(Span|Trace)ID types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/honeycombio/libhoney-go v1.12.4
 	github.com/stretchr/testify v1.5.1
-	go.opentelemetry.io/otel v0.4.2
+	go.opentelemetry.io/otel v0.4.3
 	google.golang.org/grpc v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.11 h1:Q47CePddpNGNhk4GCnAx9DDtASi2rasatE0
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-go.opentelemetry.io/otel v0.4.2 h1:nT+GOqqRR1cIY92xmo1DeiXLHtIlXH1KLRgnsnhuNrs=
-go.opentelemetry.io/otel v0.4.2/go.mod h1:OgNpQOjrlt33Ew6Ds0mGjmcTQg/rhUctsbkRdk/g1fw=
+go.opentelemetry.io/otel v0.4.3 h1:CroUX/0O1ZDcF0iWOO8gwYFWb5EbdSF0/C1yosO+Vhs=
+go.opentelemetry.io/otel v0.4.3/go.mod h1:jzBIgIzK43Iu1BpDAXwqOd6UPsSAk+ewVZ5ofSXw4Ek=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -346,8 +346,8 @@ func honeycombSpan(s *trace.SpanData) *span {
 	sc := s.SpanContext
 
 	hcSpan := &span{
-		TraceID:         getHoneycombTraceID(sc.TraceIDString()),
-		ID:              sc.SpanIDString(),
+		TraceID:         getHoneycombTraceID(sc.TraceID.String()),
+		ID:              sc.SpanID.String(),
 		Name:            s.Name,
 		HasRemoteParent: s.HasRemoteParent,
 	}
@@ -494,8 +494,8 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 
 		spanEv.Add(spanEvent{
 			Name:       a.Name,
-			TraceID:    getHoneycombTraceID(data.SpanContext.TraceIDString()),
-			ParentID:   data.SpanContext.SpanIDString(),
+			TraceID:    getHoneycombTraceID(data.SpanContext.TraceID.String()),
+			ParentID:   data.SpanContext.SpanID.String(),
 			ParentName: data.Name,
 			SpanType:   "span_event",
 		})
@@ -519,10 +519,10 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 	for _, spanLink := range data.Links {
 		linkEv := e.builder.NewEvent()
 		linkEv.Add(link{
-			TraceID:     getHoneycombTraceID(data.SpanContext.TraceIDString()),
-			ParentID:    data.SpanContext.SpanIDString(),
-			LinkTraceID: getHoneycombTraceID(spanLink.TraceIDString()),
-			LinkSpanID:  spanLink.SpanIDString(),
+			TraceID:     getHoneycombTraceID(data.SpanContext.TraceID.String()),
+			ParentID:    data.SpanContext.SpanID.String(),
+			LinkTraceID: getHoneycombTraceID(spanLink.TraceID.String()),
+			LinkSpanID:  spanLink.SpanID.String(),
 			SpanType:    "link",
 			// TODO(akvanhar): properly set the reference type when specs are defined
 			// see https://github.com/open-telemetry/opentelemetry-specification/issues/65

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -180,13 +180,13 @@ func TestHoneycombOutput(t *testing.T) {
 	assert.Len(mockHoneycomb.Events(), 1)
 	mainEventFields := mockHoneycomb.Events()[0].Fields()
 	traceID := mainEventFields["trace.trace_id"]
-	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceIDString())
+	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceID.String())
 	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
 
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
 	spanID := mainEventFields["trace.span_id"]
-	expectedSpanID := span.SpanContext().SpanIDString()
+	expectedSpanID := span.SpanContext().SpanID.String()
 	assert.Equal(expectedSpanID, spanID)
 
 	name := mainEventFields["name"]
@@ -231,13 +231,13 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	// Check the fields on the main span event.
 	mainEventFields := mockHoneycomb.Events()[1].Fields()
 	traceID := mainEventFields["trace.trace_id"]
-	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceIDString())
+	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceID.String())
 	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
 
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
 	spanID := mainEventFields["trace.span_id"]
-	expectedSpanID := span.SpanContext().SpanIDString()
+	expectedSpanID := span.SpanContext().SpanID.String()
 	assert.Equal(expectedSpanID, spanID)
 
 	name := mainEventFields["name"]
@@ -299,7 +299,7 @@ func TestHoneycombOutputWithLinks(t *testing.T) {
 	linkFields := mockHoneycomb.Events()[0].Fields()
 	mainEventFields := mockHoneycomb.Events()[1].Fields()
 	traceID := linkFields["trace.trace_id"]
-	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceIDString())
+	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceID.String())
 	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
 
 	assert.Equal(honeycombTranslatedTraceID, traceID)


### PR DESCRIPTION
We lost the `core.SpanContext` type's `SpanIDString` and `TraceIDString` methods, in favor of implementing the `Stringer` interface on the `core.SpanID` and `core.TraceID` types. Use the new `String` methods on those types instead.

Fixes #74.