### PR TITLE
Don't parse incoming trace ids as UUIDs.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -11,6 +12,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -18,7 +20,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELBIYWeBVh6wn+E=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
@@ -32,7 +36,9 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -70,13 +76,17 @@ github.com/klauspost/compress v1.10.5 h1:7q6vHIqubShURwQz8cQK6yIe/xC3IF0Vm7TGfqj
 github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e h1:fI6mGTyggeIYVmGhf80XFHxTupjOexbCppgTNDkv9AA=
 github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -88,10 +98,13 @@ github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37w
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 go.opentelemetry.io/otel v0.4.3 h1:CroUX/0O1ZDcF0iWOO8gwYFWb5EbdSF0/C1yosO+Vhs=
 go.opentelemetry.io/otel v0.4.3/go.mod h1:jzBIgIzK43Iu1BpDAXwqOd6UPsSAk+ewVZ5ofSXw4Ek=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
+golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -105,6 +118,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200505041828-1ed23360d12c h1:zJ0mtu4jCalhKg6Oaukv6iIkb+cOvDrajDH9DH46Q4M=
 golang.org/x/net v0.0.0-20200505041828-1ed23360d12c/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -112,6 +126,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEha
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -120,6 +135,7 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -161,4 +177,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -349,6 +349,13 @@ type span struct {
 //
 // [1]: https://github.com/jaegertracing/jaeger/blob/cd19b64413eca0f06b61d92fe29bebce1321d0b0/model/ids.go#L81
 func getHoneycombTraceID(traceID []byte) string {
+	// binary.BigEndian.Uint64() does a bounds check on traceID which will
+	// cause a panic if traceID is fewer than 8 bytes. In this case, we don't
+	// need to check for zero padding on the high part anyway, so just return a
+	// hex string.
+	if len(traceID) < traceIDShortLength {
+		return fmt.Sprintf("%x", traceID)
+	}
 	var low uint64
 	if len(traceID) == traceIDLongLength {
 		low = binary.BigEndian.Uint64(traceID[traceIDShortLength:])

--- a/honeycomb/honeycomb.go
+++ b/honeycomb/honeycomb.go
@@ -17,13 +17,13 @@ package honeycomb
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
 	"time"
 
-	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 
 	libhoney "github.com/honeycombio/libhoney-go"
@@ -322,6 +322,11 @@ const (
 	spanRefTypeFollowsFrom spanRefType = 1
 )
 
+const (
+	traceIdShortLength = 8
+	traceIdLongLength  = 16
+)
+
 // span is the format of trace events that Honeycomb accepts.
 type span struct {
 	TraceID         string  `json:"trace.trace_id"`
@@ -334,19 +339,36 @@ type span struct {
 	HasRemoteParent bool    `json:"has_remote_parent"`
 }
 
-func getHoneycombTraceID(traceID string) string {
-	hcTraceUUID, err := uuid.Parse(traceID)
-	if err != nil {
-		return ""
+// getHoneycombTraceID returns a trace_id suitable for use in honeycomb. Before
+// encoding the bytes as a hex string, we want to handle cases where we are
+// given 128 bit ids with zero padding, e.g. 0000000000000000f798a1e7f33c8af6.
+// To do this, we borrow a strategy from Jaeger [1] wherein we split the byte
+// sequence into two parts. The leftmost part could contain all zeros. We use
+// that to determine whether to return a 64 bit hex encoded string or a 128 bit
+// one.
+//
+// [1]: https://github.com/jaegertracing/jaeger/blob/cd19b64413eca0f06b61d92fe29bebce1321d0b0/model/ids.go#L81
+func getHoneycombTraceID(traceID []byte) string {
+	var high, low uint64
+	if len(traceID) == traceIdLongLength {
+		high = binary.BigEndian.Uint64(traceID[:traceIdShortLength])
+		low = binary.BigEndian.Uint64(traceID[traceIdShortLength:])
+	} else {
+		low = binary.BigEndian.Uint64(traceID)
 	}
-	return hcTraceUUID.String()
+
+	if high == 0 {
+		return fmt.Sprintf("%016x", low)
+	}
+
+	return fmt.Sprintf("%016x%016x", high, low)
 }
 
 func honeycombSpan(s *trace.SpanData) *span {
 	sc := s.SpanContext
 
 	hcSpan := &span{
-		TraceID:         getHoneycombTraceID(sc.TraceID.String()),
+		TraceID:         getHoneycombTraceID(sc.TraceID[:]),
 		ID:              sc.SpanID.String(),
 		Name:            s.Name,
 		HasRemoteParent: s.HasRemoteParent,
@@ -494,7 +516,7 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 
 		spanEv.Add(spanEvent{
 			Name:       a.Name,
-			TraceID:    getHoneycombTraceID(data.SpanContext.TraceID.String()),
+			TraceID:    getHoneycombTraceID(data.SpanContext.TraceID[:]),
 			ParentID:   data.SpanContext.SpanID.String(),
 			ParentName: data.Name,
 			SpanType:   "span_event",
@@ -519,9 +541,9 @@ func (e *Exporter) ExportSpan(ctx context.Context, data *trace.SpanData) {
 	for _, spanLink := range data.Links {
 		linkEv := e.builder.NewEvent()
 		linkEv.Add(link{
-			TraceID:     getHoneycombTraceID(data.SpanContext.TraceID.String()),
+			TraceID:     getHoneycombTraceID(data.SpanContext.TraceID[:]),
 			ParentID:    data.SpanContext.SpanID.String(),
-			LinkTraceID: getHoneycombTraceID(spanLink.TraceID.String()),
+			LinkTraceID: getHoneycombTraceID(spanLink.TraceID[:]),
 			LinkSpanID:  spanLink.SpanID.String(),
 			SpanType:    "link",
 			// TODO(akvanhar): properly set the reference type when specs are defined

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -31,22 +31,22 @@ func TestGetHoneycombTraceID(t *testing.T) {
 			want: "cbe4decd12429177",
 		},
 		{
-			name: "128-bit zero padded traceID",
+			name: "128-bit zero-padded traceID",
 			traceID: "0000000000000000cbe4decd12429177",
 			want: "cbe4decd12429177",
 		},
 		{
-			name: "128-bit non-zero padded traceID",
+			name: "128-bit non-zero-padded traceID",
 			traceID: "f23b42eac289a0fdcde48fcbe3ab1a32",
 			want: "f23b42eac289a0fdcde48fcbe3ab1a32",
 		},
 		{
-			name: "Non hex traceID",
+			name: "Non-hex traceID",
 			traceID: "foobar1",
 			want: "666f6f62617231",
 		},
 		{
-			name: "Longer non hex traceID",
+			name: "Longer non-hex traceID",
 			traceID: "foobarbaz",
 			want: "666f6f6261726261",
 		},
@@ -54,14 +54,13 @@ func TestGetHoneycombTraceID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var traceID []byte
 			traceID, err := hex.DecodeString(tt.traceID)
 			if err != nil {
 				traceID = []byte(tt.traceID)
 			}
 			got := getHoneycombTraceID(traceID)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getHoneycombTraceID:\n\tgot  %#v\n\twant %#v", got, tt.want)
+				t.Errorf("getHoneycombTraceID:\n\tgot:  %#v\n\twant: %#v", got, tt.want)
 			}
 		})
 	}

--- a/honeycomb/honeycomb_test.go
+++ b/honeycomb/honeycomb_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/global"
@@ -21,12 +19,60 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
+func TestGetHoneycombTraceID(t *testing.T) {
+	tests := []struct{
+		name string
+		traceID string
+		want string
+	}{
+		{
+			name: "64-bit traceID",
+			traceID: "cbe4decd12429177",
+			want: "cbe4decd12429177",
+		},
+		{
+			name: "128-bit zero padded traceID",
+			traceID: "0000000000000000cbe4decd12429177",
+			want: "cbe4decd12429177",
+		},
+		{
+			name: "128-bit non-zero padded traceID",
+			traceID: "f23b42eac289a0fdcde48fcbe3ab1a32",
+			want: "f23b42eac289a0fdcde48fcbe3ab1a32",
+		},
+		{
+			name: "Non hex traceID",
+			traceID: "foobar1",
+			want: "666f6f62617231",
+		},
+		{
+			name: "Longer non hex traceID",
+			traceID: "foobarbaz",
+			want: "666f6f6261726261",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var traceID []byte
+			traceID, err := hex.DecodeString(tt.traceID)
+			if err != nil {
+				traceID = []byte(tt.traceID)
+			}
+			got := getHoneycombTraceID(traceID)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getHoneycombTraceID:\n\tgot  %#v\n\twant %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExport(t *testing.T) {
 	now := time.Now().Round(time.Microsecond)
 	traceID, _ := core.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	spanID, _ := core.SpanIDFromHex("0102030405060708")
 
-	expectedTraceID := "01020304-0506-0708-090a-0b0c0d0e0f10"
+	expectedTraceID := "0102030405060708090a0b0c0d0e0f10"
 	expectedSpanID := "0102030405060708"
 
 	tests := []struct {
@@ -180,10 +226,10 @@ func TestHoneycombOutput(t *testing.T) {
 	assert.Len(mockHoneycomb.Events(), 1)
 	mainEventFields := mockHoneycomb.Events()[0].Fields()
 	traceID := mainEventFields["trace.trace_id"]
-	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceID.String())
-	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
+	spanTraceID := span.SpanContext().TraceID
+	honeycombTranslated := getHoneycombTraceID(spanTraceID[:])
 
-	assert.Equal(honeycombTranslatedTraceID, traceID)
+	assert.Equal(honeycombTranslated, traceID)
 
 	spanID := mainEventFields["trace.span_id"]
 	expectedSpanID := span.SpanContext().SpanID.String()
@@ -231,8 +277,8 @@ func TestHoneycombOutputWithMessageEvent(t *testing.T) {
 	// Check the fields on the main span event.
 	mainEventFields := mockHoneycomb.Events()[1].Fields()
 	traceID := mainEventFields["trace.trace_id"]
-	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceID.String())
-	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
+	spanTraceID := span.SpanContext().TraceID
+	honeycombTranslatedTraceID := getHoneycombTraceID(spanTraceID[:])
 
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
@@ -299,16 +345,17 @@ func TestHoneycombOutputWithLinks(t *testing.T) {
 	linkFields := mockHoneycomb.Events()[0].Fields()
 	mainEventFields := mockHoneycomb.Events()[1].Fields()
 	traceID := linkFields["trace.trace_id"]
-	honeycombTranslatedTraceUUID, _ := uuid.Parse(span.SpanContext().TraceID.String())
-	honeycombTranslatedTraceID := honeycombTranslatedTraceUUID.String()
+	spanContextTraceID := span.SpanContext().TraceID
+	honeycombTranslatedTraceID := getHoneycombTraceID(spanContextTraceID[:])
 
 	assert.Equal(honeycombTranslatedTraceID, traceID)
 
 	linkParentID := linkFields["trace.parent_id"]
 	assert.Equal(mainEventFields["trace.span_id"], linkParentID)
+
 	hclinkTraceID := linkFields["trace.link.trace_id"]
-	linkTraceIDString := hex.EncodeToString(linkTraceID[:])
-	assert.Equal(getHoneycombTraceID(linkTraceIDString), hclinkTraceID)
+	assert.Equal(getHoneycombTraceID(linkTraceID[:]), hclinkTraceID)
+
 	hclinkSpanID := linkFields["trace.link.span_id"]
 	assert.Equal("0102030405060709", hclinkSpanID)
 	linkSpanType := linkFields["meta.span_type"]


### PR DESCRIPTION
Parsing all incoming trace ids as UUIDs can introduce formatting incompatibilities between Honeycomb and other tracing tools. Specifically, Jaeger supports either 64-bit or 128-bit trace ids. The OpenTelemetry Collector will left-pad 64-bit ids with 0s, which were then being converted into UUIDs by the Honeycomb exporter, leading to strings like 00000000-0000-0000-cbe4-decd12429177.

This change simply accepts either 64-bit or 128-bit ids and doesn't parse them into UUIDs. The above example would be passed through as cbe4decd12429177.