### PR TITLE
use a libhoney.Client; switch from libhoney.Output to transmission.Sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* `withHoneycombSender` exporter option for specifying a `libhoney` `transmission.Sender`
+
+### Changed
+
+* The exporter now creates an isolated `libhoney.Client` instead of using the package-level api.  This reduces interactions between multiple libhoney-based instrumentations if they're run in the same process.
+
+### Removed
+
+* `withHoneycombOutput` exporter option.  `libhoney`'s `Output` interface is deprecated (in favor of `transmission.Sender` above) and will be removed at some point.


### PR DESCRIPTION
using a `libhoney.Client` should isolate the exporter a bit more from the rest of a user's code (if they happen to be using another `libhoney.Client`, or the package api.)  We can drop the `Builder` and use the client instead.

`libhoney.ClientConfig` doesn't support an `Output` field, so we need to switch from `libhoney.Output` to `transmission.Sender`.  This is a breaking change:  here we drop `withHoneycombOutput` and replace it with `withHoneycombSender`.

There is one remaining thing to call out about `libhoney.Client` isolation - `libhoney.UserAgentAddition`.

1. By offering a way for user code to specify a `transmission.Sender`, we lose the ability to specify the user agent at all in those cases.  Not sure if there's code in the wild that does this.  The tests are the only place within the repo that does, and since we're mocking it's not a big deal at all.
2. given the only way to modify Client user agents _without_ specifying a `transmission.Sender` is to set the package global, execution order of multiple clients can affect those clients' user agents - they can race, or the order may not be deterministic.

definitely not an issue for this repo, but instead something probably work fixing in libhoney-go.