### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @honeycombio/integrations-team


### PR DESCRIPTION
Adds @honeycombio/integrations-team as codeowneres for this repo.

Once this is merged, we can set the branch protection rule to require review from codeowners to accept PRs.